### PR TITLE
Added --silent option for runtime indicator

### DIFF
--- a/cmd/cli_flags/flags.go
+++ b/cmd/cli_flags/flags.go
@@ -7,26 +7,27 @@ import (
 	"github.com/citihub/probr/internal/config"
 )
 
-type flagHandlerFunc func(v *string)
+type flagHandlerFunc func(v interface{})
 
 type Flag struct {
 	Handler flagHandlerFunc
-	Value   *string
+	Value   interface{}
 }
 
 var flags []Flag
 
-func (f *Flag) executeHandler() {
+func (f Flag) executeHandler() {
 	f.Handler(f.Value)
 }
 
 func HandleFlags() {
 
-	createFlag("varsFile", "", "path to config file", varsFileHandler)
-	createFlag("outputDir", "", "output directory", outputDirHandler) // Must run prior to creating outputType flag
-	createFlag("outputType", "", "output defaults to write in memory, if 'IO' will write to specified output directory", outputTypeHandler)
-	createFlag("tags", "", "test tags, e.g. -tags=\"@CIS-1.2.3, @CIS-4.5.6\".", tagsHandler)
-	createFlag("kubeConfig", "", "kube config file", kubeConfigHandler)
+	stringFlag("varsFile", "path to config file", varsFileHandler)
+	stringFlag("outputDir", "output directory", outputDirHandler) // Must run prior to creating outputType flag
+	stringFlag("outputType", "output defaults to write in memory, if 'IO' will write to specified output directory", outputTypeHandler)
+	stringFlag("tags", "test tags, e.g. -tags=\"@CIS-1.2.3, @CIS-4.5.6\".", tagsHandler)
+	stringFlag("kubeConfig", "kube config file", kubeConfigHandler)
+	boolFlag("silent", "Disable visual runtime indicator, useful for CI tasks", silentHandler)
 	flag.Parse()
 
 	for _, f := range flags {
@@ -34,51 +35,63 @@ func HandleFlags() {
 	}
 }
 
-func createFlag(n string, d string, t string, h flagHandlerFunc) {
+func stringFlag(name string, usage string, handler flagHandlerFunc) {
 	f := Flag{
-		Handler: h,
+		Handler: handler,
 		Value:   new(string),
 	}
-	flag.StringVar(f.Value, n, d, t)
+	v := f.Value.(*string)
+	flag.StringVar(v, name, "", usage)
+	flags = append(flags, f)
+}
+
+func boolFlag(name string, usage string, handler flagHandlerFunc) {
+	f := Flag{
+		Handler: handler,
+		Value:   new(bool),
+	}
+	v := f.Value.(*bool)
+	flag.BoolVar(v, name, false, usage)
 	flags = append(flags, f)
 }
 
 // varsFileHandler initializes configuration with varsFile overriding env vars & defaults
-func varsFileHandler(v *string) {
-	err := config.Init(*v)
+func varsFileHandler(v interface{}) {
+	err := config.Init(*v.(*string))
 	if err != nil {
-		log.Fatalf("[ERROR] Could not create config from provided filepath: %v", *v)
-	} else if len(*v) > 0 {
-		log.Printf("[NOTICE] Config read from file '%s', but may still be overridden by CLI flags.", *v)
+		log.Fatalf("[ERROR] Could not create config from provided filepath: %v", v.(*string))
+	} else if len(*v.(*string)) > 0 {
+		log.Printf("[NOTICE] Config read from file '%s', but may still be overridden by CLI flags.", v.(*string))
 	} else {
 		log.Printf("[NOTICE] No configuration variables file specified. Using environment variabls and defaults only.")
 	}
 }
 
 // outputDirHandler
-func outputDirHandler(v *string) {
-	if len(*v) > 0 {
+func outputDirHandler(v interface{}) {
+	if len(*v.(*string)) > 0 {
 		log.Printf("[NOTICE] Output Directory has been overridden via command line")
+		config.Vars.CucumberDir = *v.(*string)
 	}
 }
 
 // outputTypeHandler validates provided value and sets output accordingly
-func outputTypeHandler(v *string) {
-	if len(*v) > 0 {
-		if *v == "IO" {
-			log.Printf("[NOTICE] Probr results will be written to files in the specified output directory: %v", *v)
-		} else if *v == "INMEM" {
+func outputTypeHandler(v interface{}) {
+	if len(*v.(*string)) > 0 {
+		if *v.(*string) == "IO" {
+			log.Printf("[NOTICE] Probr results will be written to files in the specified output directory: %v", v.(*string))
+		} else if *v.(*string) == "INMEM" {
 			log.Printf("[NOTICE] Output type specified as INMEM: Results will not be handled by the CLI. Refer to the Summary Log for a results summary.")
 		} else {
-			log.Fatalf("[ERROR] Unknown output type specified: %s. Please use 'IO' or 'INMEM'", *v)
+			log.Fatalf("[ERROR] Unknown output type specified: %s. Please use 'IO' or 'INMEM'", v.(*string))
 		}
-		config.Vars.OutputType = *v
+		config.Vars.OutputType = *v.(*string)
 	}
 }
 
-func tagsHandler(v *string) {
-	if len(*v) > 0 {
-		config.Vars.Tags = *v
+func tagsHandler(v interface{}) {
+	if len(*v.(*string)) > 0 {
+		config.Vars.Tags = *v.(*string)
 		log.Printf("[NOTICE] Tags have been added via command line.")
 	}
 	if len(config.Vars.GetTags()) == 0 {
@@ -86,12 +99,26 @@ func tagsHandler(v *string) {
 	}
 }
 
-func kubeConfigHandler(v *string) {
-	if len(*v) > 0 {
-		config.Vars.KubeConfigPath = *v
+func kubeConfigHandler(v interface{}) {
+	if len(*v.(*string)) > 0 {
+		config.Vars.KubeConfigPath = *v.(*string)
 		log.Printf("[NOTICE] Kubeconfig path has been overridden via command line")
 	}
 	if len(config.Vars.KubeConfigPath) == 0 {
 		log.Printf("[NOTICE] No kubeconfig path specified. Falling back to default paths.")
 	}
+}
+
+func silentHandler(v interface{}) {
+	config.Vars.Silent = isFlagPassed("silent")
+}
+
+func isFlagPassed(flagName string) bool {
+	found := false
+	flag.Visit(func(f *flag.Flag) {
+		if f.Name == flagName {
+			found = true
+		}
+	})
+	return found
 }

--- a/cmd/cli_flags/flags.go
+++ b/cmd/cli_flags/flags.go
@@ -55,13 +55,16 @@ func boolFlag(name string, usage string, handler flagHandlerFunc) {
 	flags = append(flags, f)
 }
 
+// Note:
+// Even though it's a bit ugly, using things like `*v.(*string)` comes from accepting bool, string, and other flag types
+
 // varsFileHandler initializes configuration with varsFile overriding env vars & defaults
 func varsFileHandler(v interface{}) {
 	err := config.Init(*v.(*string))
 	if err != nil {
 		log.Fatalf("[ERROR] Could not create config from provided filepath: %v", v.(*string))
 	} else if len(*v.(*string)) > 0 {
-		log.Printf("[NOTICE] Config read from file '%s', but may still be overridden by CLI flags.", v.(*string))
+		log.Printf("[NOTICE] Config read from file '%v', but may still be overridden by CLI flags.", v.(*string))
 	} else {
 		log.Printf("[NOTICE] No configuration variables file specified. Using environment variabls and defaults only.")
 	}
@@ -83,7 +86,7 @@ func outputTypeHandler(v interface{}) {
 		} else if *v.(*string) == "INMEM" {
 			log.Printf("[NOTICE] Output type specified as INMEM: Results will not be handled by the CLI. Refer to the Summary Log for a results summary.")
 		} else {
-			log.Fatalf("[ERROR] Unknown output type specified: %s. Please use 'IO' or 'INMEM'", v.(*string))
+			log.Fatalf("[ERROR] Unknown output type specified: %v. Please use 'IO' or 'INMEM'", v.(*string))
 		}
 		config.Vars.OutputType = *v.(*string)
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -27,7 +27,7 @@ func main() {
 	cli_flags.HandleFlags()
 	config.LogConfigState()
 
-	if config.Vars.LogLevel == "ERROR" {
+	if showIndicator() {
 		// At this loglevel, Probr is often silent for long periods. Add a visual runtime indicator.
 		config.Spinner = spinner.New(spinner.CharSets[42], 500*time.Millisecond)
 		config.Spinner.Start()
@@ -57,6 +57,10 @@ func main() {
 	}
 	summary.State.PrintSummary()
 	exit(s)
+}
+
+func showIndicator() bool {
+	return (config.Vars.LogLevel == "ERROR" && !config.Vars.Silent)
 }
 
 func exit(status int) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -42,7 +42,8 @@ type ConfigVars struct {
 	Probes             []Probe  `yaml:"probes"`
 	SystemClusterRoles []string `yaml:"systemClusterRoles"`
 	Tags               string   `yaml:"tags"`
-	TagExclusions      []string // not from yaml
+	Silent             bool     // set by flags only
+	TagExclusions      []string // set programatically
 }
 
 type Probe struct {


### PR DESCRIPTION
- CLI now silences visual runtime indicator if `--silent` is passed
- Includes function that can help with bool flag handling