### PR TITLE
removed Curl and BusyBox image configuration parameters

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -6,8 +6,6 @@ overwriteHistoricalAudits: true
 summaryEnabled: true
 images:
     repository:
-    curl:
-    busyBox:
 azure:
     subscriptionID:
     clientID:

--- a/config.yml
+++ b/config.yml
@@ -4,8 +4,7 @@ auditDir: audit_output
 cucumberDir: cucumber_output
 overwriteHistoricalAudits: true
 summaryEnabled: true
-images:
-    repository:
+imagesRepository:
 azure:
     subscriptionID:
     clientID:

--- a/internal/clouddriver/kubernetes/iam.go
+++ b/internal/clouddriver/kubernetes/iam.go
@@ -87,7 +87,7 @@ func (i *IAM) setenv() {
 
 	// image repository + curl from config
 	// but default if not supplied
-	ig := config.Vars.Images.Repository
+	ig := config.Vars.ImagesRepository
 	//need to fudge for 'curl' as it's registered as curlimages/curl
 	//on docker, so if we've been given a repository from the config
 	//and it's 'docker.io' then ignore it and set default (curlimages)

--- a/internal/clouddriver/kubernetes/iam.go
+++ b/internal/clouddriver/kubernetes/iam.go
@@ -23,9 +23,9 @@ const (
 	//NOTE: either the above namespace needs to be added to the exclusion list on the
 	//container registry rule or busybox need to be available in the allowed (probably internal) registry
 	defaultIAMImageRepository = "curlimages"
-	defaultIAMProbeImage       = "curl"
-	defaultIAMProbeContainer   = "iam-test"
-	defaultIAMProbePodName     = "iam-test-pod"
+	defaultIAMProbeImage      = "curl"
+	defaultIAMProbeContainer  = "iam-test"
+	defaultIAMProbePodName    = "iam-test-pod"
 )
 
 // IAMProbeCommand defines commands for use in testing IAM
@@ -94,12 +94,8 @@ func (i *IAM) setenv() {
 	if len(ig) < 1 || ig == "docker.io" {
 		ig = defaultIAMImageRepository
 	}
-	b := config.Vars.Images.Curl
-	if len(b) < 1 {
-		b = defaultIAMProbeImage
-	}
 
-	i.probeImage = ig + "/" + b
+	i.probeImage = ig + "/" + defaultIAMProbeImage
 
 	i.testAzureIdentityBinding = "probr-specificns-aib"
 }

--- a/internal/clouddriver/kubernetes/networkaccess.go
+++ b/internal/clouddriver/kubernetes/networkaccess.go
@@ -11,11 +11,11 @@ import (
 
 const (
 	//default values.  Overrides can be set via the environment.
-	defaultNAProbeNamespace   = "probr-network-access-test-ns" //this needs to be set up as an exculsion in the image registry policy
+	defaultNAProbeNamespace  = "probr-network-access-test-ns" //this needs to be set up as an exculsion in the image registry policy
 	defaultNAImageRepository = "curlimages"
-	defaultNAProbeImage       = "curl"
-	defaultNAProbeContainer   = "na-test"
-	defaultNAProbePodName     = "na-test-pod"
+	defaultNAProbeImage      = "curl"
+	defaultNAProbeContainer  = "na-test"
+	defaultNAProbePodName    = "na-test-pod"
 )
 
 // NetworkAccess defines functionality for supporting Network Access tests.
@@ -71,12 +71,7 @@ func (n *NA) setup() {
 		i = defaultNAImageRepository
 	}
 
-	b := config.Vars.Images.Curl
-	if len(b) < 1 {
-		b = defaultNAProbeImage
-	}
-
-	n.probeImage = i + "/" + b
+	n.probeImage = i + "/" + defaultNAProbeImage
 }
 
 // ClusterIsDeployed verifies if a suitable cluster is deployed.

--- a/internal/clouddriver/kubernetes/networkaccess.go
+++ b/internal/clouddriver/kubernetes/networkaccess.go
@@ -63,7 +63,7 @@ func (n *NA) setup() {
 
 	// image repository + curl from config
 	// but default if not supplied
-	i := config.Vars.Images.Repository
+	i := config.Vars.ImagesRepository
 	//need to fudge for 'curl' as it's registered as curlimages/curl
 	//on docker, so if we've been given a repository from the config
 	//and it's 'docker.io' then ignore it and set default (curlimages)

--- a/internal/clouddriver/kubernetes/podsecuritypolicy.go
+++ b/internal/clouddriver/kubernetes/podsecuritypolicy.go
@@ -140,18 +140,14 @@ func (psp *PSP) setenv() {
 	psp.probeContainer = defaultPSPProbeContainer
 	psp.probePodName = defaultPSPProbePodName
 
-	// image repository + busy box from config
+	// image repository from config
 	// but default if not supplied
 	i := config.Vars.Images.Repository
 	if len(i) < 1 {
 		i = defaultPSPImageRepository
 	}
-	b := config.Vars.Images.BusyBox
-	if len(b) < 1 {
-		b = defaultPSPProbeImage
-	}
 
-	psp.probeImage = i + "/" + b
+	psp.probeImage = i + "/" + defaultPSPProbeImage
 }
 
 // ClusterIsDeployed verifies that a suitable kubernetes cluster is deployed.

--- a/internal/clouddriver/kubernetes/podsecuritypolicy.go
+++ b/internal/clouddriver/kubernetes/podsecuritypolicy.go
@@ -142,7 +142,7 @@ func (psp *PSP) setenv() {
 
 	// image repository from config
 	// but default if not supplied
-	i := config.Vars.Images.Repository
+	i := config.Vars.ImagesRepository
 	if len(i) < 1 {
 		i = defaultPSPImageRepository
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,10 +22,8 @@ type ConfigVars struct {
 	AuditEnabled              string `yaml:"auditEnabled"`
 	LogLevel                  string `yaml:"logLevel"`
 	OverwriteHistoricalAudits string `yaml:"overwriteHistoricalAudits"`
-	Images                    struct {
-		Repository string `yaml:"repository"`
-	} `yaml:"images"`
-	Azure struct {
+	ImagesRepository          string `yaml:"imagesRepository"`
+	Azure                     struct {
 		SubscriptionID  string `yaml:"subscriptionID"`
 		ClientID        string `yaml:"clientID"`
 		ClientSecret    string `yaml:"clientSecret"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,8 +24,6 @@ type ConfigVars struct {
 	OverwriteHistoricalAudits string `yaml:"overwriteHistoricalAudits"`
 	Images                    struct {
 		Repository string `yaml:"repository"`
-		Curl       string `yaml:"curl"`
-		BusyBox    string `yaml:"busyBox"`
 	} `yaml:"images"`
 	Azure struct {
 		SubscriptionID  string `yaml:"subscriptionID"`

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -20,9 +20,7 @@ func setFromEnvOrDefaults(e *ConfigVars) {
 	e.set(&e.AuditDir, "PROBR_AUDIT_DIR", "audit_output")
 	e.set(&e.LogLevel, "PROBR_LOG_LEVEL", "ERROR")
 	e.set(&e.OverwriteHistoricalAudits, "OVERWRITE_AUDITS", "true")
-
-	e.set(&e.Images.Repository, "PROBR_IMAGE_REPOSITORY", "docker.io")
-
+	e.set(&e.ImagesRepository, "PROBR_IMAGES_REPOSITORY", "docker.io")
 	e.set(&e.Azure.SubscriptionID, "AZURE_SUBSCRIPTION_ID", "")
 	e.set(&e.Azure.ClientID, "AZURE_CLIENT_ID", "")
 	e.set(&e.Azure.ClientSecret, "AZURE_CLIENT_SECRET", "")

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -21,9 +21,7 @@ func setFromEnvOrDefaults(e *ConfigVars) {
 	e.set(&e.LogLevel, "PROBR_LOG_LEVEL", "ERROR")
 	e.set(&e.OverwriteHistoricalAudits, "OVERWRITE_AUDITS", "true")
 
-	e.set(&e.Images.Repository, "IMAGE_REPOSITORY", "docker.io")
-	e.set(&e.Images.Curl, "CURL_IMAGE", "curl")
-	e.set(&e.Images.BusyBox, "BUSYBOX_IMAGE", "busybox")
+	e.set(&e.Images.Repository, "PROBR_IMAGE_REPOSITORY", "docker.io")
 
 	e.set(&e.Azure.SubscriptionID, "AZURE_SUBSCRIPTION_ID", "")
 	e.set(&e.Azure.ClientID, "AZURE_CLIENT_ID", "")

--- a/probes/kubernetes/container_registry_access.go
+++ b/probes/kubernetes/container_registry_access.go
@@ -26,11 +26,11 @@ func SetContainerRegistryAccess(c kubernetes.ContainerRegistryAccess) {
 // CIS-6.1.3
 // Minimize cluster access to read-only
 func (s *scenarioState) iAmAuthorisedToPullFromAContainerRegistry() error {
-	pod, podAudit, err := cra.SetupContainerAccessProbePod(config.Vars.Images.Repository)
+	pod, podAudit, err := cra.SetupContainerAccessProbePod(config.Vars.ImagesRepository)
 
 	err = ProcessPodCreationResult(s.probe, &s.podState, pod, kubernetes.PSPContainerAllowedImages, err)
 
-	description := fmt.Sprintf("Creates a new pod using an image from %s. Passes if image successfully pulls and pod is built.", config.Vars.Images.Repository)
+	description := fmt.Sprintf("Creates a new pod using an image from %s. Passes if image successfully pulls and pod is built.", config.Vars.ImagesRepository)
 	payload := podPayload(pod, podAudit)
 	s.audit.AuditScenarioStep(description, payload, err)
 

--- a/probes/kubernetes/general_feature.go
+++ b/probes/kubernetes/general_feature.go
@@ -59,7 +59,7 @@ func (s *scenarioState) iShouldOnlyFindWildcardsInKnownAndAuthorisedConfiguratio
 func (s *scenarioState) iAttemptToCreateADeploymentWhichDoesNotHaveASecurityContext() error {
 	cname := "probr-general"
 	pod_name := kubernetes.GenerateUniquePodName(cname)
-	image := config.Vars.Images.Repository + "/" + gfProbeImage
+	image := config.Vars.ImagesRepository + "/" + gfProbeImage
 
 	//create pod with nil security context
 	pod, podAudit, err := kubernetes.GetKubeInstance().CreatePod(pod_name, "probr-general-test-ns", cname, image, true, nil)

--- a/probes/kubernetes/general_feature.go
+++ b/probes/kubernetes/general_feature.go
@@ -14,6 +14,11 @@ import (
 	"github.com/cucumber/godog"
 )
 
+const (
+	// general feature container image
+	gfProbeImage = "busybox"
+)
+
 // BUG - This step doesn't run
 //@CIS-5.1.3
 func (s *scenarioState) iInspectTheThatAreConfigured(roleLevel string) error {
@@ -54,7 +59,7 @@ func (s *scenarioState) iShouldOnlyFindWildcardsInKnownAndAuthorisedConfiguratio
 func (s *scenarioState) iAttemptToCreateADeploymentWhichDoesNotHaveASecurityContext() error {
 	cname := "probr-general"
 	pod_name := kubernetes.GenerateUniquePodName(cname)
-	image := config.Vars.Images.Repository + "/" + config.Vars.Images.BusyBox
+	image := config.Vars.Images.Repository + "/" + gfProbeImage
 
 	//create pod with nil security context
 	pod, podAudit, err := kubernetes.GetKubeInstance().CreatePod(pod_name, "probr-general-test-ns", cname, image, true, nil)


### PR DESCRIPTION
To address issue 53 I have removed the Curl and BusyBox configuration params, but left the Images Repository as configurable.
Consider whether we should change the YAML config from 'Images/Repository' to simply ImagesRepository