### PR TITLE
Corrected pod counters

### DIFF
--- a/examples/config.yml
+++ b/examples/config.yml
@@ -6,7 +6,7 @@ SummaryEnabled: true
 ImagesRepository:
 ServicePacks:
   Kubernetes:
-    KubeConfig: .kube/config
+    KubeConfig:
     KubeContext:
 CloudProviders:
   Azure:
@@ -24,11 +24,11 @@ Probes: # this entire object can be left out if all tests are to be run
     Justification: "demo"
 
   - Name: container_registry_access
-    Excluded: false
+    Excluded: true
     Justification: "demo"
 
   - Name: general
-    Excluded: false
+    Excluded: true
     Justification: "demo"
 
   - Name: iam_control
@@ -36,9 +36,9 @@ Probes: # this entire object can be left out if all tests are to be run
     Justification: "demo"
 
   - Name: internet_access
-    Excluded: false
+    Excluded: true
     Justification: "demo"
 
   - Name: pod_security_policy
-    Excluded: false
+    Excluded: true
     Justification: "demo"

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -1,9 +1,10 @@
+# Empty and omitted keys will use default values
 AuditEnabled: true
 AuditDir: audit_output
 CucumberDir: cucumber_output
 OverwriteHistoricalAudits: true
 SummaryEnabled: true
-ImagesRepository:
+ContainerRegistry:
 ServicePacks:
   Kubernetes:
     KubeConfig:
@@ -24,21 +25,21 @@ Probes: # this entire object can be left out if all tests are to be run
     Justification: "demo"
 
   - Name: container_registry_access
-    Excluded: true
+    Excluded: false
     Justification: "demo"
 
   - Name: general
-    Excluded: true
+    Excluded: false
     Justification: "demo"
 
-  - Name: iam_control
+  - Name: iam
     Excluded: false
     Justification: "demo"
 
   - Name: internet_access
-    Excluded: true
+    Excluded: false
     Justification: "demo"
 
   - Name: pod_security_policy
-    Excluded: true
+    Excluded: false
     Justification: "demo"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -57,9 +57,9 @@ type azure struct {
 }
 
 type Probe struct {
-	Name          string `yaml:"name"`
-	Excluded      bool   `yaml:"excluded"`
-	Justification string `yaml:"justification"`
+	Name          string `yaml:"Name"`
+	Excluded      bool   `yaml:"Excluded"`
+	Justification string `yaml:"Justification"`
 }
 
 // Vars is a singleton instance of ConfigVars
@@ -68,13 +68,16 @@ var Spinner *spinner.Spinner
 
 // GetTags parses Tags with TagExclusions
 func (ctx *ConfigVars) GetTags() string {
-
-	for _, v := range ctx.Probes {
-		if v.Excluded {
-			ctx.HandleExclusion(v.Name, v.Justification)
+	if ctx.Tags == "" {
+		if len(ctx.Probes) > 0 {
+			log.Printf("[WARN] Exclusions are being ignored due to Tags being set.")
+		}
+		for _, v := range ctx.Probes {
+			if v.Excluded {
+				ctx.HandleExclusion(v.Name, v.Justification)
+			}
 		}
 	}
-
 	return ctx.Tags
 }
 

--- a/internal/summary/README.md
+++ b/internal/summary/README.md
@@ -75,21 +75,6 @@ os.Exit(s)
 
 Whenever Probr will create or destroy a pod, these counters should be called to update the probe accordingly.
 
-```
-if pd != nil {
-  s.PodName = pd.GetObjectMeta().GetName()
-  e.CountPodCreated()
-  summary.State.LogPodName(s.PodName)
-}
-```
-
-```
-if wait {
-  waitForDelete(c, ns, pname)
-}
-summary.State.GetProbeLog(probe).CountPodDestroyed()
-```
-
 **Probe.AuditScenarioStep**
 
 This function should be used every time a step in a scenario completes. `AuditScenarioStep` will automatically form the name of the step from the name of the function that called it. The name value provided will establish which scenario the step is a part of. The error (or nil) provided will dictate whether the test passes or fails.

--- a/internal/summary/probes.go
+++ b/internal/summary/probes.go
@@ -17,7 +17,8 @@ type Probe struct {
 }
 
 // CountPodCreated increments pods_created for probe
-func (e *Probe) CountPodCreated() {
+func (e *Probe) CountPodCreated(podName string) {
+	State.LogPodName(podName)
 	e.PodsCreated = e.PodsCreated + 1
 }
 

--- a/service_packs/kubernetes/container_registry_access/container_registry_access.go
+++ b/service_packs/kubernetes/container_registry_access/container_registry_access.go
@@ -37,7 +37,7 @@ func (s *scenarioState) aKubernetesClusterIsDeployed() error {
 // CIS-6.1.3
 // Minimize cluster access to read-only
 func (s *scenarioState) iAmAuthorisedToPullFromAContainerRegistry() error {
-	pod, podAudit, err := cra.SetupContainerAccessProbePod(config.Vars.ContainerRegistry)
+	pod, podAudit, err := cra.SetupContainerAccessProbePod(config.Vars.ContainerRegistry, s.probe)
 
 	err = kubernetes.ProcessPodCreationResult(s.probe, &s.podState, pod, kubernetes.PSPContainerAllowedImages, err)
 
@@ -61,7 +61,7 @@ func (s *scenarioState) thePushRequestIsRejectedDueToAuthorization() error {
 // CIS-6.1.4
 // Ensure only authorised container registries are allowed
 func (s *scenarioState) aUserAttemptsToDeployAContainerFrom(auth string, registry string) error {
-	pod, podAudit, err := cra.SetupContainerAccessProbePod(registry)
+	pod, podAudit, err := cra.SetupContainerAccessProbePod(registry, s.probe)
 
 	err = kubernetes.ProcessPodCreationResult(s.probe, &s.podState, pod, kubernetes.PSPContainerAllowedImages, err)
 

--- a/service_packs/kubernetes/container_registry_access/helpers.go
+++ b/service_packs/kubernetes/container_registry_access/helpers.go
@@ -20,7 +20,7 @@ const (
 // ContainerRegistryAccess interface defines the methods to support container registry access tests.
 type ContainerRegistryAccess interface {
 	ClusterIsDeployed() *bool
-	SetupContainerAccessProbePod(r string) (*apiv1.Pod, *kubernetes.PodAudit, error)
+	SetupContainerAccessProbePod(r string, probe *summary.Probe) (*apiv1.Pod, *kubernetes.PodAudit, error)
 	TeardownContainerAccessProbePod(p *string, e string) error
 }
 
@@ -62,13 +62,13 @@ func (c *CRA) ClusterIsDeployed() *bool {
 }
 
 //SetupContainerAccessProbePod creates a pod with characteristics required for testing container access.
-func (c *CRA) SetupContainerAccessProbePod(r string) (*apiv1.Pod, *kubernetes.PodAudit, error) {
+func (c *CRA) SetupContainerAccessProbePod(r string, probe *summary.Probe) (*apiv1.Pod, *kubernetes.PodAudit, error) {
 	//full image is the repository + the configured image
 	i := r + "/" + config.Vars.ProbeImage
 	pname := kubernetes.GenerateUniquePodName(caPodNameBase + "-" + strings.ReplaceAll(r, ".", "-"))
 	ns, cname := caNamespace, caContainer
 	// let caller handle result ...
-	return c.k.CreatePod(pname, ns, cname, i, true, nil)
+	return c.k.CreatePod(pname, ns, cname, i, true, nil, probe)
 }
 
 //TeardownContainerAccessProbePod deletes the supplied test pod in the container registry access namespace.

--- a/service_packs/kubernetes/general/general.go
+++ b/service_packs/kubernetes/general/general.go
@@ -67,7 +67,7 @@ func (s *scenarioState) iAttemptToCreateADeploymentWhichDoesNotHaveASecurityCont
 	image := config.Vars.ContainerRegistry + "/" + config.Vars.ProbeImage
 
 	//create pod with nil security context
-	pod, podAudit, err := kubernetes.GetKubeInstance().CreatePod(pod_name, "probr-general-test-ns", cname, image, true, nil)
+	pod, podAudit, err := kubernetes.GetKubeInstance().CreatePod(pod_name, "probr-general-test-ns", cname, image, true, nil, s.probe)
 
 	err = kubernetes.ProcessPodCreationResult(s.probe, &s.podState, pod, kubernetes.UndefinedPodCreationErrorReason, err)
 

--- a/service_packs/kubernetes/iam/iam.feature
+++ b/service_packs/kubernetes/iam/iam.feature
@@ -1,5 +1,5 @@
 @kubernetes
-@iam_control
+@iam
 @CIS-6.8
 @AZ-AAD-AI
 Feature: Ensure stringent authentication and authorisation

--- a/service_packs/kubernetes/iam/iam.go
+++ b/service_packs/kubernetes/iam/iam.go
@@ -80,7 +80,7 @@ func (s *scenarioState) iCreateASimplePodInNamespaceAssignedWithThatAzureIdentit
 		if namespace == "the default" {
 			s.useDefaultNS = true
 		}
-		pd, err := iam.CreateIAMProbePod(y, s.useDefaultNS)
+		pd, err := iam.CreateIAMProbePod(y, s.useDefaultNS, s.probe)
 		err = kubernetes.ProcessPodCreationResult(s.probe, &s.podState, pd, kubernetes.UndefinedPodCreationErrorReason, err)
 	}
 
@@ -190,7 +190,7 @@ func (s *scenarioState) iDeployAPodAssignedWithTheAzureIdentityBindingIntoTheSam
 		err = utils.ReformatError("error reading yaml for test: %v", err)
 		log.Print(err)
 	} else {
-		pd, err := iam.CreateIAMProbePod(y, false)
+		pd, err := iam.CreateIAMProbePod(y, false, s.probe)
 		err = kubernetes.ProcessPodCreationResult(s.probe, &s.podState, pd, kubernetes.UndefinedPodCreationErrorReason, err)
 	}
 

--- a/service_packs/kubernetes/internet_access/helpers.go
+++ b/service_packs/kubernetes/internet_access/helpers.go
@@ -43,7 +43,7 @@ const (
 // NetworkAccess defines functionality for supporting Network Access tests.
 type NetworkAccess interface {
 	ClusterIsDeployed() *bool
-	SetupNetworkAccessProbePod() (*apiv1.Pod, *kubernetes.PodAudit, error)
+	SetupNetworkAccessProbePod(probe *summary.Probe) (*apiv1.Pod, *kubernetes.PodAudit, error)
 	TeardownNetworkAccessProbePod(p *string, e string) error
 	AccessURL(pn *string, url *string) (int, error)
 }
@@ -93,10 +93,10 @@ func (n *NA) ClusterIsDeployed() *bool {
 }
 
 // SetupNetworkAccessProbePod creates a pod with characteristics required for testing network access.
-func (n *NA) SetupNetworkAccessProbePod() (*apiv1.Pod, *kubernetes.PodAudit, error) {
+func (n *NA) SetupNetworkAccessProbePod(probe *summary.Probe) (*apiv1.Pod, *kubernetes.PodAudit, error) {
 	pname, ns, cname, image := kubernetes.GenerateUniquePodName(n.probePodName), n.probeNamespace, n.probeContainer, n.probeImage
 	//let caller handle result:
-	return n.k.CreatePod(pname, ns, cname, image, true, nil)
+	return n.k.CreatePod(pname, ns, cname, image, true, nil, probe)
 }
 
 // TeardownNetworkAccessProbePod deletes the test pod with the given name.

--- a/service_packs/kubernetes/internet_access/internet_access.go
+++ b/service_packs/kubernetes/internet_access/internet_access.go
@@ -45,7 +45,7 @@ func (s *scenarioState) aPodIsDeployedInTheCluster() error {
 		//only one pod is needed for all scenarios in this probe
 		log.Printf("[DEBUG] Pod %v has already been created - reusing the pod", s.podName)
 	} else {
-		pd, pa, e := na.SetupNetworkAccessProbePod()
+		pd, pa, e := na.SetupNetworkAccessProbePod(s.probe)
 		podAudit = pa
 		pod = pd
 		if e != nil {

--- a/service_packs/kubernetes/kube.go
+++ b/service_packs/kubernetes/kube.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/citihub/probr/internal/config"
+	"github.com/citihub/probr/internal/summary"
 	"github.com/citihub/probr/internal/utils"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -69,9 +70,9 @@ type Kubernetes interface {
 	ClusterIsDeployed() *bool
 	GetClient() (*kubernetes.Clientset, error)
 	GetPods(ns string) (*apiv1.PodList, error)
-	CreatePod(pname string, ns string, cname string, image string, w bool, sc *apiv1.SecurityContext) (*apiv1.Pod, *PodAudit, error)
-	CreatePodFromObject(p *apiv1.Pod, pname string, ns string, w bool) (*apiv1.Pod, error)
-	CreatePodFromYaml(y []byte, pname string, ns string, image string, aadpodidbinding string, w bool) (*apiv1.Pod, error)
+	CreatePod(pname string, ns string, cname string, image string, w bool, sc *apiv1.SecurityContext, probe *summary.Probe) (*apiv1.Pod, *PodAudit, error)
+	CreatePodFromObject(pod *apiv1.Pod, podName string, ns string, wait bool, probe *summary.Probe) (*apiv1.Pod, error)
+	CreatePodFromYaml(y []byte, pname string, ns string, image string, aadpodidbinding string, w bool, probe *summary.Probe) (*apiv1.Pod, error)
 	GetPodObject(pname string, ns string, cname string, image string, sc *apiv1.SecurityContext) *apiv1.Pod
 	ExecCommand(cmd, ns, pn *string) *CmdExecutionResult
 	DeletePod(pname *string, ns *string, w bool, e string) error
@@ -181,18 +182,18 @@ func (k *Kube) GetPods(ns string) (*apiv1.PodList, error) {
 
 // CreatePod creates a pod with the supplied parameters.  A true value for 'wait' indicates that
 // the function should wait (block) until the pod is in a running state.
-func (k *Kube) CreatePod(podName string, ns string, containerName string, image string, wait bool, sc *apiv1.SecurityContext) (*apiv1.Pod, *PodAudit, error) {
+func (k *Kube) CreatePod(podName string, ns string, containerName string, image string, wait bool, sc *apiv1.SecurityContext, probe *summary.Probe) (*apiv1.Pod, *PodAudit, error) {
 	//create Pod Objet ...
 	p := k.GetPodObject(podName, ns, containerName, image, sc)
 	audit := &PodAudit{podName, "probr-general-test-ns", containerName, image, sc}
 
-	pod, err := k.CreatePodFromObject(p, podName, ns, wait)
+	pod, err := k.CreatePodFromObject(p, podName, ns, wait, probe)
 	return pod, audit, err
 }
 
 // CreatePodFromYaml creates a pod for the supplied yaml.  A true value for 'w' indicates that the function
 // should wait (block) until the pod is in a running state.
-func (k *Kube) CreatePodFromYaml(y []byte, pname string, ns string, image string, aadpodidbinding string, w bool) (*apiv1.Pod, error) {
+func (k *Kube) CreatePodFromYaml(y []byte, pname string, ns string, image string, aadpodidbinding string, w bool, probe *summary.Probe) (*apiv1.Pod, error) {
 
 	decode := scheme.Codecs.UniversalDeserializer().Decode
 
@@ -216,18 +217,18 @@ func (k *Kube) CreatePodFromYaml(y []byte, pname string, ns string, image string
 		p.Labels["aadpodidbinding"] = aadpodidbinding
 	}
 
-	return k.CreatePodFromObject(p, pname, ns, w)
+	return k.CreatePodFromObject(p, pname, ns, w, probe)
 }
 
 // CreatePodFromObject creates a pod from the supplied pod object with the given pod name and namespace.  A true value for 'w' indicates that the function
 // should wait (block) until the pod is in a running state.
-func (k *Kube) CreatePodFromObject(p *apiv1.Pod, pname string, ns string, w bool) (*apiv1.Pod, error) {
-	if p == nil || pname == "" || ns == "" {
-		return nil, fmt.Errorf("one or more of pod (%v), podName (%v) or namespace (%v) is nil - cannot create POD", p, pname, ns)
+func (k *Kube) CreatePodFromObject(pod *apiv1.Pod, podName string, ns string, wait bool, probe *summary.Probe) (*apiv1.Pod, error) {
+	if pod == nil || podName == "" || ns == "" {
+		return nil, fmt.Errorf("one or more of pod (%v), podName (%v) or namespace (%v) is nil - cannot create POD", pod, podName, ns)
 	}
 
-	log.Printf("[INFO] Creating pod %v in namespace %v", pname, ns)
-	log.Printf("[DEBUG] Pod details: %+v", *p)
+	log.Printf("[INFO] Creating pod %v in namespace %v", podName, ns)
+	log.Printf("[DEBUG] Pod details: %+v", *pod)
 
 	c, err := k.GetClient()
 	if err != nil {
@@ -246,16 +247,16 @@ func (k *Kube) CreatePodFromObject(p *apiv1.Pod, pname string, ns string, w bool
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	res, err := pc.Create(ctx, p, metav1.CreateOptions{})
+	res, err := pc.Create(ctx, pod, metav1.CreateOptions{})
 	if err != nil {
 		if isAlreadyExists(err) {
-			log.Printf("[NOTICE] POD %v already exists. Returning existing.", pname)
-			res, _ := pc.Get(ctx, pname, metav1.GetOptions{})
+			log.Printf("[NOTICE] POD %v already exists. Returning existing.", podName)
+			res, _ := pc.Get(ctx, podName, metav1.GetOptions{})
 
 			//return it and nil out err
 			return res, nil
 		} else if isForbidden(err) {
-			log.Printf("[NOTICE] Creation of POD %v is forbidden: %v", pname, err)
+			log.Printf("[NOTICE] Creation of POD %v is forbidden: %v", podName, err)
 			//return a specific error:
 			return nil, &PodCreationError{err, *k.toPodCreationErrorCode(err)}
 		}
@@ -264,16 +265,14 @@ func (k *Kube) CreatePodFromObject(p *apiv1.Pod, pname string, ns string, w bool
 
 	log.Printf("[INFO] POD %q creation started.", res.GetObjectMeta().GetName())
 
-	if w {
-		//wait:
-		err = k.waitForPhase(apiv1.PodRunning, c, &ns, &pname)
+	if wait {
+		err = k.waitForPhase(apiv1.PodRunning, c, &ns, &podName)
 		if err != nil {
 			return res, err
 		}
 	}
-
+	probe.CountPodCreated()
 	log.Printf("[INFO] POD %q creation completed. Pod is up and running.", res.GetObjectMeta().GetName())
-
 	return res, nil
 }
 
@@ -439,7 +438,12 @@ func (k *Kube) ExecCommand(cmd, ns, pn *string) (s *CmdExecutionResult) {
 
 // DeletePod deletes the given pod in the specified namespace.
 // Passing true for 'wait' causes the function to wait for pod deletion (not normally required).
-func (k *Kube) DeletePod(pname *string, ns *string, wait bool, probe string) error {
+func (k *Kube) DeletePod(podName *string, ns *string, wait bool, probeName string) error {
+	_, err := k.PodStatus(*podName, *ns)
+	if err != nil {
+		return err // If pod does not exist, it cannot be deleted
+	}
+
 	c, err := k.GetClient()
 	if err != nil {
 		return err
@@ -450,17 +454,31 @@ func (k *Kube) DeletePod(pname *string, ns *string, wait bool, probe string) err
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	err = pc.Delete(ctx, *pname, metav1.DeleteOptions{})
+	err = pc.Delete(ctx, *podName, metav1.DeleteOptions{})
 	if err != nil {
 		return err
 	}
 
 	if wait {
-		waitForDelete(c, ns, pname, probe)
+		waitForDelete(c, ns, podName)
 	}
-	log.Printf("[INFO] POD %v deleted.", *pname)
+	summary.State.GetProbeLog(probeName).CountPodDestroyed()
+	log.Printf("[INFO] POD %v deleted.", *podName)
 
 	return nil
+}
+
+func (k *Kube) PodStatus(name, ns string) (apiv1.PodStatus, error) {
+	client, err := k.GetClient()
+	if err != nil {
+		return apiv1.PodStatus{}, err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	pod, err := client.CoreV1().Pods(ns).Get(ctx, name, metav1.GetOptions{})
+	return pod.Status, err
 }
 
 func (k *Kube) createNamespace(ns *string) (*apiv1.Namespace, error) {

--- a/service_packs/kubernetes/kube.go
+++ b/service_packs/kubernetes/kube.go
@@ -271,7 +271,7 @@ func (k *Kube) CreatePodFromObject(pod *apiv1.Pod, podName string, ns string, wa
 			return res, err
 		}
 	}
-	probe.CountPodCreated()
+	probe.CountPodCreated(podName)
 	log.Printf("[INFO] POD %q creation completed. Pod is up and running.", res.GetObjectMeta().GetName())
 	return res, nil
 }

--- a/service_packs/kubernetes/kubernetes.go
+++ b/service_packs/kubernetes/kubernetes.go
@@ -66,7 +66,6 @@ func ProcessPodCreationResult(probe *summary.Probe, s *PodState, pd *apiv1.Pod, 
 		//in this case we need to hold onto the name so it can be deleted
 		if pd != nil {
 			s.PodName = pd.GetObjectMeta().GetName()
-			summary.State.LogPodName(s.PodName)
 		}
 
 		//check for known error type
@@ -92,7 +91,6 @@ func ProcessPodCreationResult(probe *summary.Probe, s *PodState, pd *apiv1.Pod, 
 	//if we've got this far, a pod was successfully created which could be
 	//valid for some tests
 	s.PodName = pd.GetObjectMeta().GetName()
-	summary.State.LogPodName(s.PodName)
 
 	//we're good
 	return nil

--- a/service_packs/kubernetes/kubernetes.go
+++ b/service_packs/kubernetes/kubernetes.go
@@ -66,7 +66,6 @@ func ProcessPodCreationResult(probe *summary.Probe, s *PodState, pd *apiv1.Pod, 
 		//in this case we need to hold onto the name so it can be deleted
 		if pd != nil {
 			s.PodName = pd.GetObjectMeta().GetName()
-			probe.CountPodCreated()
 			summary.State.LogPodName(s.PodName)
 		}
 
@@ -93,7 +92,6 @@ func ProcessPodCreationResult(probe *summary.Probe, s *PodState, pd *apiv1.Pod, 
 	//if we've got this far, a pod was successfully created which could be
 	//valid for some tests
 	s.PodName = pd.GetObjectMeta().GetName()
-	probe.CountPodCreated()
 	summary.State.LogPodName(s.PodName)
 
 	//we're good

--- a/service_packs/kubernetes/kubernetes_mock.go
+++ b/service_packs/kubernetes/kubernetes_mock.go
@@ -1,6 +1,7 @@
 package kubernetes
 
 import (
+	"github.com/citihub/probr/internal/summary"
 	"github.com/stretchr/testify/mock"
 	apiv1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -32,20 +33,20 @@ func (m *KubeMock) GetPods(ns string) (*apiv1.PodList, error) {
 	e := a.Error(1)
 	return pl, e
 }
-func (m *KubeMock) CreatePod(pname string, ns string, cname string, image string, w bool, sc *apiv1.SecurityContext) (*apiv1.Pod, *PodAudit, error) {
+func (m *KubeMock) CreatePod(pname string, ns string, cname string, image string, w bool, sc *apiv1.SecurityContext, probe *summary.Probe) (*apiv1.Pod, *PodAudit, error) {
 	//The below will check the args are as expected, ie. the security context has the correct attributes
 	a := m.Called(pname, ns, cname, image, w, sc)
 
 	return a.Get(0).(*apiv1.Pod), &PodAudit{}, a.Error(1)
 }
-func (m *KubeMock) CreatePodFromObject(p *apiv1.Pod, pname string, ns string, w bool) (*apiv1.Pod, error) {
+func (m *KubeMock) CreatePodFromObject(p *apiv1.Pod, pname string, ns string, w bool, probe *summary.Probe) (*apiv1.Pod, error) {
 	//The below will check the args are as expected, ie. the Pod has the correct attributes
 	a := m.Called(p, pname, ns, w)
 
 	//This time, return the pod we've been given, so ignore what's been supplied on the mock call:
 	return p, a.Error(1)
 }
-func (m *KubeMock) CreatePodFromYaml(y []byte, pname string, ns string, image string, identityBinding string, w bool) (*apiv1.Pod, error) {
+func (m *KubeMock) CreatePodFromYaml(y []byte, pname string, ns string, image string, identityBinding string, w bool, probe *summary.Probe) (*apiv1.Pod, error) {
 	po := m.Called().Get(0).(*apiv1.Pod)
 	e := m.Called().Error(1)
 	return po, e

--- a/service_packs/kubernetes/pod_handlers.go
+++ b/service_packs/kubernetes/pod_handlers.go
@@ -9,7 +9,6 @@ import (
 	"math/rand"
 	"time"
 
-	"github.com/citihub/probr/internal/summary"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -129,7 +128,7 @@ func defaultContainerSecurityContext() *apiv1.SecurityContext {
 	}
 }
 
-func waitForDelete(c *k8s.Clientset, ns *string, n *string, probeName string) error {
+func waitForDelete(c *k8s.Clientset, ns *string, n *string) error {
 
 	ps := c.CoreV1().Pods(*ns)
 
@@ -152,7 +151,6 @@ func waitForDelete(c *k8s.Clientset, ns *string, n *string, probeName string) er
 		log.Printf("[DEBUG] Watch Container status: %+v", p.Status.ContainerStatuses)
 
 		if e.Type == "DELETED" {
-			summary.State.GetProbeLog(probeName).CountPodDestroyed()
 			log.Printf("[INFO] DELETED probe received for pod %v", p.GetObjectMeta().GetName())
 			break
 		}

--- a/service_packs/kubernetes/pod_security_policy/helpers.go
+++ b/service_packs/kubernetes/pod_security_policy/helpers.go
@@ -100,11 +100,11 @@ type PodSecurityPolicy interface {
 	HostPortsAreRestricted() (*bool, error)
 	VolumeTypesAreRestricted() (*bool, error)
 	SeccompProfilesAreRestricted() (*bool, error)
-	CreatePODSettingSecurityContext(pr *bool, pe *bool, runAsUser *int64) (*apiv1.Pod, error)
-	CreatePODSettingAttributes(hostPID *bool, hostIPC *bool, hostNetwork *bool) (*apiv1.Pod, error)
-	CreatePODSettingCapabilities(c *[]string) (*apiv1.Pod, error)
-	CreatePodFromYaml(y []byte) (*apiv1.Pod, error)
-	ExecPSPProbeCmd(pName *string, cmd PSPProbeCommand) (*kubernetes.CmdExecutionResult, error)
+	CreatePODSettingSecurityContext(pr *bool, pe *bool, runAsUser *int64, probe *summary.Probe) (*apiv1.Pod, error)
+	CreatePODSettingAttributes(hostPID *bool, hostIPC *bool, hostNetwork *bool, probe *summary.Probe) (*apiv1.Pod, error)
+	CreatePODSettingCapabilities(c *[]string, probe *summary.Probe) (*apiv1.Pod, error)
+	CreatePodFromYaml(y []byte, probe *summary.Probe) (*apiv1.Pod, error)
+	ExecPSPProbeCmd(pName *string, cmd PSPProbeCommand, probe *summary.Probe) (*kubernetes.CmdExecutionResult, error)
 	TeardownPodSecurityProbe(p *string, e string) error
 	CreateConfigMap() error
 	DeleteConfigMap() error
@@ -468,7 +468,7 @@ func logAndReturn(t string, s bool, r bool, e error) (*bool, error) {
 // pr *bool - set the Privileged flag.  Defaults to false.
 // pe *bool - set the Allow Privileged Escalation flag.  Defaults to false.
 // runAsUser *int64 - set RunAsUser.  Defaults to 1000.
-func (psp *PSP) CreatePODSettingSecurityContext(pr *bool, pe *bool, runAsUser *int64) (*apiv1.Pod, error) {
+func (psp *PSP) CreatePODSettingSecurityContext(pr *bool, pe *bool, runAsUser *int64, probe *summary.Probe) (*apiv1.Pod, error) {
 	//default sensibly if not provided
 	//this needs to take account of rules around allowedPrivilegdEscalation and Privileged:
 	// cannot set `allowPrivilegeEscalation` to false and `privileged` to true
@@ -505,7 +505,7 @@ func (psp *PSP) CreatePODSettingSecurityContext(pr *bool, pe *bool, runAsUser *i
 	pname, ns, cname, image := kubernetes.GenerateUniquePodName(psp.probePodName), psp.probeNamespace, psp.probeContainer, psp.probeImage
 
 	//let caller handle ...
-	pod, _, err := psp.k.CreatePod(pname, ns, cname, image, true, &sc)
+	pod, _, err := psp.k.CreatePod(pname, ns, cname, image, true, &sc, probe)
 	return pod, err
 }
 
@@ -513,7 +513,7 @@ func (psp *PSP) CreatePODSettingSecurityContext(pr *bool, pe *bool, runAsUser *i
 // hostPID *bool - set the hostPID flag, defaults to false
 // hostIPC *bool - set the hostIPC flag, defaults to false
 // hostNetwork *bool - set the hostNetwork flag, defaults to false
-func (psp *PSP) CreatePODSettingAttributes(hostPID *bool, hostIPC *bool, hostNetwork *bool) (*apiv1.Pod, error) {
+func (psp *PSP) CreatePODSettingAttributes(hostPID *bool, hostIPC *bool, hostNetwork *bool, probe *summary.Probe) (*apiv1.Pod, error) {
 	//default sensibly if not provided
 	f := false
 	if hostPID == nil {
@@ -535,11 +535,11 @@ func (psp *PSP) CreatePODSettingAttributes(hostPID *bool, hostIPC *bool, hostNet
 	po.Spec.HostNetwork = *hostNetwork
 
 	// create from PO (and let caller handle ...)
-	return psp.k.CreatePodFromObject(po, pname, ns, true)
+	return psp.k.CreatePodFromObject(po, pname, ns, true, probe)
 }
 
 // CreatePODSettingCapabilities creates a pod with the supplied capabilities.
-func (psp *PSP) CreatePODSettingCapabilities(c *[]string) (*apiv1.Pod, error) {
+func (psp *PSP) CreatePODSettingCapabilities(c *[]string, probe *summary.Probe) (*apiv1.Pod, error) {
 	pname, ns, cname, image := kubernetes.GenerateUniquePodName(psp.probePodName), psp.probeNamespace, psp.probeContainer, psp.probeImage
 
 	// get the pod object and manipulate:
@@ -562,24 +562,24 @@ func (psp *PSP) CreatePODSettingCapabilities(c *[]string) (*apiv1.Pod, error) {
 	}
 
 	// create from PO (and let caller handle ...)
-	return psp.k.CreatePodFromObject(po, pname, ns, true)
+	return psp.k.CreatePodFromObject(po, pname, ns, true, probe)
 }
 
 // CreatePodFromYaml creates a pod from the supplied yaml.
-func (psp *PSP) CreatePodFromYaml(y []byte) (*apiv1.Pod, error) {
+func (psp *PSP) CreatePodFromYaml(y []byte, probe *summary.Probe) (*apiv1.Pod, error) {
 	pname := kubernetes.GenerateUniquePodName(psp.probePodName)
 
-	return psp.k.CreatePodFromYaml(y, pname, psp.probeNamespace, psp.probeImage, "", true)
+	return psp.k.CreatePodFromYaml(y, pname, psp.probeNamespace, psp.probeImage, "", true, probe)
 }
 
 // ExecPSPProbeCmd executes the given PSPProbeCommand against the supplied pod name.
-func (psp *PSP) ExecPSPProbeCmd(pName *string, cmd PSPProbeCommand) (*kubernetes.CmdExecutionResult, error) {
+func (psp *PSP) ExecPSPProbeCmd(pName *string, cmd PSPProbeCommand, probe *summary.Probe) (*kubernetes.CmdExecutionResult, error) {
 	var pn string
 	//if we've not been given a pod name, assume one needs to be created:
 	if pName == nil {
 		//want one without privileged access or escalation
 		f := false
-		p, err := psp.CreatePODSettingSecurityContext(&f, &f, nil)
+		p, err := psp.CreatePODSettingSecurityContext(&f, &f, nil, probe)
 
 		if err != nil {
 			return nil, err

--- a/service_packs/kubernetes/pod_security_policy/pod_security_policy.go
+++ b/service_packs/kubernetes/pod_security_policy/pod_security_policy.go
@@ -91,7 +91,7 @@ func (s *scenarioState) runVerificationProbe(c VerificationProbe) error {
 
 	//check for lack of creation error, i.e. pod was created successfully
 	if s.podState.CreationError == nil {
-		res, err := psp.ExecPSPProbeCmd(&s.podState.PodName, c.Cmd)
+		res, err := psp.ExecPSPProbeCmd(&s.podState.PodName, c.Cmd, s.probe)
 
 		//analyse the results
 		if err != nil {
@@ -143,7 +143,7 @@ func (s *scenarioState) privilegedAccessRequestIsMarkedForTheKubernetesDeploymen
 		pa = false
 	}
 
-	pd, err := psp.CreatePODSettingSecurityContext(&pa, nil, nil)
+	pd, err := psp.CreatePODSettingSecurityContext(&pa, nil, nil, s.probe)
 
 	err = kubernetes.ProcessPodCreationResult(s.probe, &s.podState, pd, kubernetes.PSPNoPrivilege, err)
 
@@ -185,7 +185,7 @@ func (s *scenarioState) hostPIDRequestIsMarkedForTheKubernetesDeployment(hostPID
 		hostPID = false
 	}
 
-	pd, err := psp.CreatePODSettingAttributes(&hostPID, nil, nil)
+	pd, err := psp.CreatePODSettingAttributes(&hostPID, nil, nil, s.probe)
 
 	err = kubernetes.ProcessPodCreationResult(s.probe, &s.podState, pd, kubernetes.PSPHostNamespace, err)
 
@@ -226,7 +226,7 @@ func (s *scenarioState) hostIPCRequestIsMarkedForTheKubernetesDeployment(hostIPC
 		hostIPC = false
 	}
 
-	pd, err := psp.CreatePODSettingAttributes(nil, &hostIPC, nil)
+	pd, err := psp.CreatePODSettingAttributes(nil, &hostIPC, nil, s.probe)
 
 	err = kubernetes.ProcessPodCreationResult(s.probe, &s.podState, pd, kubernetes.PSPHostNamespace, err)
 
@@ -268,7 +268,7 @@ func (s *scenarioState) hostNetworkRequestIsMarkedForTheKubernetesDeployment(hos
 		hostNetwork = false
 	}
 
-	pd, err := psp.CreatePODSettingAttributes(nil, nil, &hostNetwork)
+	pd, err := psp.CreatePODSettingAttributes(nil, nil, &hostNetwork, s.probe)
 
 	err = kubernetes.ProcessPodCreationResult(s.probe, &s.podState, pd, kubernetes.PSPHostNetwork, err)
 
@@ -309,7 +309,7 @@ func (s *scenarioState) privilegedEscalationIsMarkedForTheKubernetesDeployment(p
 		pa = false
 	}
 
-	pd, err := psp.CreatePODSettingSecurityContext(nil, &pa, nil)
+	pd, err := psp.CreatePODSettingSecurityContext(nil, &pa, nil, s.probe)
 
 	err = kubernetes.ProcessPodCreationResult(s.probe, &s.podState, pd, kubernetes.PSPNoPrivilegeEscalation, err)
 
@@ -342,7 +342,7 @@ func (s *scenarioState) theUserRequestedIsForTheKubernetesDeployment(requestedUs
 		runAsUser = 1000
 	}
 
-	pd, err := psp.CreatePODSettingSecurityContext(nil, nil, &runAsUser)
+	pd, err := psp.CreatePODSettingSecurityContext(nil, nil, &runAsUser, s.probe)
 	err = kubernetes.ProcessPodCreationResult(s.probe, &s.podState, pd, kubernetes.PSPAllowedUsersGroups, err)
 
 	description := ""
@@ -381,7 +381,7 @@ func (s *scenarioState) nETRAWIsMarkedForTheKubernetesDeployment(netRawRequested
 		c[0] = "NET_RAW"
 	}
 
-	pd, err := psp.CreatePODSettingCapabilities(&c)
+	pd, err := psp.CreatePODSettingCapabilities(&c, s.probe)
 	err = kubernetes.ProcessPodCreationResult(s.probe, &s.podState, pd, kubernetes.PSPAllowedCapabilities, err)
 
 	description := ""
@@ -421,7 +421,7 @@ func (s *scenarioState) additionalCapabilitiesForTheKubernetesDeployment(addCapa
 		c[0] = "NET_ADMIN"
 	}
 
-	pd, err := psp.CreatePODSettingCapabilities(&c)
+	pd, err := psp.CreatePODSettingCapabilities(&c, s.probe)
 	err = kubernetes.ProcessPodCreationResult(s.probe, &s.podState, pd, kubernetes.PSPAllowedCapabilities, err)
 
 	description := ""
@@ -462,7 +462,7 @@ func (s *scenarioState) assignedCapabilitiesForTheKubernetesDeployment(assignCap
 		c[0] = "NET_ADMIN"
 	}
 
-	pd, err := psp.CreatePODSettingCapabilities(&c)
+	pd, err := psp.CreatePODSettingCapabilities(&c, s.probe)
 	err = kubernetes.ProcessPodCreationResult(s.probe, &s.podState, pd, kubernetes.PSPAllowedCapabilities, err)
 
 	description := ""
@@ -505,7 +505,7 @@ func (s *scenarioState) anPortRangeIsRequestedForTheKubernetesDeployment(portRan
 	}
 
 	if err == nil {
-		pd, err := psp.CreatePodFromYaml(y)
+		pd, err := psp.CreatePodFromYaml(y, s.probe)
 		err = kubernetes.ProcessPodCreationResult(s.probe, &s.podState, pd, kubernetes.PSPAllowedPortRange, err)
 	}
 
@@ -550,7 +550,7 @@ func (s *scenarioState) anVolumeTypeIsRequestedForTheKubernetesDeployment(volume
 	}
 
 	if err == nil {
-		pd, err := psp.CreatePodFromYaml(y)
+		pd, err := psp.CreatePodFromYaml(y, s.probe)
 		err = kubernetes.ProcessPodCreationResult(s.probe, &s.podState, pd, kubernetes.PSPAllowedVolumeTypes, err)
 	}
 
@@ -593,7 +593,7 @@ func (s *scenarioState) anSeccompProfileIsRequestedForTheKubernetesDeployment(se
 	}
 
 	if err != nil {
-		pd, err := psp.CreatePodFromYaml(y)
+		pd, err := psp.CreatePodFromYaml(y, s.probe)
 		err = kubernetes.ProcessPodCreationResult(s.probe, &s.podState, pd, kubernetes.PSPSeccompProfile, err)
 	}
 

--- a/service_packs/kubernetes/pod_security_policy/podsecuritypolicy_test.go
+++ b/service_packs/kubernetes/pod_security_policy/podsecuritypolicy_test.go
@@ -205,11 +205,11 @@ func TestCreatePODSettingSecurityContext(t *testing.T) {
 		RunAsUser:                utils.Int64Ptr(2000),
 	}
 
-	mk.On("CreatePod", mock.Anything, mock.Anything, mock.Anything, mock.Anything, true, &sc).
+	mk.On("CreatePod", mock.Anything, mock.Anything, mock.Anything, mock.Anything, true, &sc, mock.Anything, mock.Anything).
 		Return(k.GetPodObject("n", "ns", "c", "i", &sc), nil).Once()
 
 	//privileged and privileged access true, runasuser 2000
-	p, err := psp.CreatePODSettingSecurityContext(utils.BoolPtr(true), utils.BoolPtr(true), utils.Int64Ptr(2000))
+	p, err := psp.CreatePODSettingSecurityContext(utils.BoolPtr(true), utils.BoolPtr(true), utils.Int64Ptr(2000), nil)
 
 	//don't expect an error
 	assert.Nil(t, err)
@@ -230,10 +230,10 @@ func TestCreatePODSettingSecurityContext(t *testing.T) {
 		AllowPrivilegeEscalation: utils.BoolPtr(true),
 		RunAsUser:                utils.Int64Ptr(1000),
 	}
-	mk.On("CreatePod", mock.Anything, mock.Anything, mock.Anything, mock.Anything, true, &sc).
+	mk.On("CreatePod", mock.Anything, mock.Anything, mock.Anything, mock.Anything, true, &sc, mock.Anything, mock.Anything).
 		Return(k.GetPodObject("n", "ns", "c", "i", &sc), nil).Once()
 
-	p, err = psp.CreatePODSettingSecurityContext(utils.BoolPtr(false), utils.BoolPtr(true), nil)
+	p, err = psp.CreatePODSettingSecurityContext(utils.BoolPtr(false), utils.BoolPtr(true), nil, nil)
 
 	//don't expect an error
 	assert.Nil(t, err)
@@ -259,11 +259,11 @@ func TestCreatePODSettingAttributes(t *testing.T) {
 	po := k.GetPodObject("n", "ns", "c", "i", nil)
 	mk.On("GetPodObject", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(po, nil)
-	mk.On("CreatePodFromObject", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+	mk.On("CreatePodFromObject", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(po, nil)
 
 	//hostPID, hostIPC & hostNetwork all true:
-	p, err := psp.CreatePODSettingAttributes(utils.BoolPtr(true), utils.BoolPtr(true), utils.BoolPtr(true))
+	p, err := psp.CreatePODSettingAttributes(utils.BoolPtr(true), utils.BoolPtr(true), utils.BoolPtr(true), nil)
 
 	//don't expect an error
 	assert.Nil(t, err)
@@ -278,7 +278,7 @@ func TestCreatePODSettingAttributes(t *testing.T) {
 	mk.AssertExpectations(t)
 
 	//hostPID, hostIPC & hostNetwork all false:
-	p, err = psp.CreatePODSettingAttributes(utils.BoolPtr(false), utils.BoolPtr(false), utils.BoolPtr(false))
+	p, err = psp.CreatePODSettingAttributes(utils.BoolPtr(false), utils.BoolPtr(false), utils.BoolPtr(false), nil)
 
 	//don't expect an error
 	assert.Nil(t, err)
@@ -293,7 +293,7 @@ func TestCreatePODSettingAttributes(t *testing.T) {
 	mk.AssertExpectations(t)
 
 	//hostPID, hostIPC & hostNetwork mixed:
-	p, err = psp.CreatePODSettingAttributes(utils.BoolPtr(false), utils.BoolPtr(true), nil)
+	p, err = psp.CreatePODSettingAttributes(utils.BoolPtr(false), utils.BoolPtr(true), nil, nil)
 
 	//don't expect an error
 	assert.Nil(t, err)
@@ -308,7 +308,7 @@ func TestCreatePODSettingAttributes(t *testing.T) {
 	mk.AssertExpectations(t)
 
 	//hostPID, hostIPC & hostNetwork all nil (should default to false):
-	p, err = psp.CreatePODSettingAttributes(nil, nil, nil)
+	p, err = psp.CreatePODSettingAttributes(nil, nil, nil, nil)
 
 	//don't expect an error
 	assert.Nil(t, err)
@@ -333,11 +333,11 @@ func TestCreatePODSettingCapabilities(t *testing.T) {
 	po := k.GetPodObject("n", "ns", "c", "i", nil)
 	mk.On("GetPodObject", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(po, nil)
-	mk.On("CreatePodFromObject", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+	mk.On("CreatePodFromObject", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(po, nil)
 
 	//no capabilities:
-	p, err := psp.CreatePODSettingCapabilities(nil)
+	p, err := psp.CreatePODSettingCapabilities(nil, nil)
 
 	//don't expect an error
 	assert.Nil(t, err)
@@ -354,7 +354,7 @@ func TestCreatePODSettingCapabilities(t *testing.T) {
 
 	//some capabilities:
 	c := []string{"NET_RAW"}
-	p, err = psp.CreatePODSettingCapabilities(&c)
+	p, err = psp.CreatePODSettingCapabilities(&c, nil)
 
 	//don't expect an error
 	assert.Nil(t, err)

--- a/service_packs/service_packs.go
+++ b/service_packs/service_packs.go
@@ -4,7 +4,7 @@ import (
 	"path/filepath"
 
 	"github.com/cucumber/godog"
-	packr "github.com/gobuffalo/packr/v2"
+	"github.com/gobuffalo/packr/v2"
 
 	"github.com/citihub/probr/internal/coreengine"
 	"github.com/citihub/probr/service_packs/kubernetes/container_registry_access"
@@ -20,11 +20,9 @@ type probe interface {
 	Name() string
 }
 
-var packrBox *packr.Box
 var packs map[string][]probe
 
 func init() {
-	packrBox = packr.New("box", "") // Allows static filepaths within this directory to be referenced even within the binary
 	packs = make(map[string][]probe)
 	packs["kubernetes"] = []probe{
 		container_registry_access.Probe,
@@ -36,12 +34,14 @@ func init() {
 }
 
 func makeGodogProbe(pack string, p probe) *coreengine.GodogProbe {
-	pd := coreengine.ProbeDescriptor{Group: coreengine.Kubernetes, Name: p.Name()}
+	box := packr.New(pack+p.Name(), filepath.Join(pack, p.Name())) // Establish static files for binary build
+	descriptor := coreengine.ProbeDescriptor{Group: coreengine.Kubernetes, Name: p.Name()}
+	path := filepath.Join(box.ResolutionDir, p.Name()+".feature")
 	return &coreengine.GodogProbe{
-		ProbeDescriptor:     &pd,
+		ProbeDescriptor:     &descriptor,
 		ProbeInitializer:    p.ProbeInitialize,
 		ScenarioInitializer: p.ScenarioInitialize,
-		FeaturePath:         filepath.Join(packrBox.ResolutionDir, pack, p.Name(), p.Name()+".feature"),
+		FeaturePath:         path,
 	}
 }
 


### PR DESCRIPTION
Pod counters were being used in locations that didn't always trigger. Needed to pass probe summary object through every logic stream to ensure that the summary is properly logging the change (or passing the probe name and fetching the summary object could have worked as well, but the difference seemed irrelevant)