### PR TITLE
Removed storage pack activation

### DIFF
--- a/service_packs/service_packs.go
+++ b/service_packs/service_packs.go
@@ -12,8 +12,6 @@ import (
 	"github.com/citihub/probr/service_packs/kubernetes/iam"
 	"github.com/citihub/probr/service_packs/kubernetes/internet_access"
 	"github.com/citihub/probr/service_packs/kubernetes/pod_security_policy"
-	"github.com/citihub/probr/service_packs/storage/access_whitelisting"
-	"github.com/citihub/probr/service_packs/storage/encryption_in_flight"
 )
 
 type probe interface {
@@ -32,10 +30,6 @@ func init() {
 		pod_security_policy.Probe,
 		internet_access.Probe,
 		iam.Probe,
-	}
-	packs["storage"] = []probe{
-		encryption_in_flight.Probe,
-		access_whitelisting.Probe,
 	}
 }
 


### PR DESCRIPTION
Storage pack contains extra behavior that doesn't work without a proper resource to target (even if the pack's tags are excluded). This removes the activation of the storage pack.