### PR TITLE
Feature/requirements handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The following elements are required to get started with Probr:
 
 1. Run the probr executable via `./probr [OPTIONS]`. 
     - Additional options can be seen via `./probr --help`
-    - Review required variables via `./probr show-required <SERVICE PACK NAME>`
+    - Review required variables by using `./probr show-requirements <SERVICE-PACK-NAME; optional>`
 
 ## Configuration
 

--- a/cmd/cli_flags/required_vars.go
+++ b/cmd/cli_flags/required_vars.go
@@ -3,24 +3,30 @@ package cli_flags
 import (
 	"fmt"
 	"os"
+
+	"github.com/citihub/probr/internal/config"
 )
 
 func HandleRequestForRequiredVars() {
-	if os.Args[1] == "show-required" {
-		switch os.Args[2] {
-		case "kubernetes":
-			respond("Kubernetes", "AuthorisedContainerRegistry", "UnauthorisedContainerRegistry")
-		case "storage":
-			respond("Storage", "Provider")
-		default:
-			fmt.Printf("Unknown service pack specified, cannot get required variables")
+	if os.Args[1] == "show-requirements" {
+		for req := range config.Requirements {
+			if len(os.Args) > 2 {
+				// Show specified
+				if os.Args[2] == req {
+					respond(req, config.Requirements[req]...)
+					os.Exit(0)
+				}
+			} else {
+				// Show all
+				respond(req, config.Requirements[req]...)
+			}
 		}
-		os.Exit(0) // Don't continue if this option is called
+		os.Exit(0) // Never run probr if 'show-requirements' is called
 	}
 }
 
 func respond(pack string, vars ...string) {
-	fmt.Printf("Required variables for %s service pack:\n", pack)
+	fmt.Printf("Required variables for %s:\n", pack)
 	for _, v := range vars {
 		fmt.Printf("    %s\n", v)
 	}

--- a/internal/config/requirements.go
+++ b/internal/config/requirements.go
@@ -1,0 +1,6 @@
+package config
+
+var Requirements = map[string][]string{
+	"Storage":    []string{"Provider"},
+	"Kubernetes": []string{"AuthorisedContainerRegistry", "UnauthorisedContainerRegistry"},
+}

--- a/service_packs/README.md
+++ b/service_packs/README.md
@@ -96,21 +96,23 @@ of step functions.
          }
       ```
 
-1. Add an `IsExcluded` function to config.yml with at least one required variable. Without this, your service pack will be run by default (which is undesired behavior).
+1. Add an `IsExcluded` function to `internal/config` with at least one required variable. Without this, your service pack will be run by default (which is undesired behavior).
 
    ```go
       // internal/config/config.go
+      // Log and return exclusion configuration
       func (s Storage) IsExcluded() bool {
-         if s.Provider == "" {
-            if !s.exclusionLogged {
-               log.Printf("[WARN] Ignoring Storage service pack due to required vars not being present.")
-               s.exclusionLogged = true
-            }
-            return true
-         }
-         log.Printf("[NOTICE] Storage service pack included.")
-         return false
+         return validatePackRequirements("Storage", s)
       }
+   ```
+
+   ```go
+      // internal/config/requirements.go
+      var Requirements = map[string][]string{
+         "Storage":    []string{"Provider"},
+         "Kubernetes": []string{"AuthorisedContainerRegistry", "UnauthorisedContainerRegistry"},
+      }
+
    ```
 
 1. Add the service pack and its probes to `service_packs/service_packs.go`


### PR DESCRIPTION
Required variables are now in one location: `internal/config/requirements.go`

Service pack `IsExcluded()` functions (required for all packs) should now utilize `validatePackRequirements(...)`

CLI option `show-requirements` (formerly "show-required") now automatically populates using the values from `internal/config/requirements.go`