### PR TITLE
Fixing bug in storage service pack: state.ctx was nil in anAzureResourceGroupExists

### DIFF
--- a/service_packs/storage/azure/access_whitelisting/access_whitelisting.go
+++ b/service_packs/storage/azure/access_whitelisting/access_whitelisting.go
@@ -49,7 +49,6 @@ type scenarioState struct {
 func (state *scenarioState) setup() {
 
 	log.Println("[DEBUG] Setting up \"AccessWhitelistingAzure\"")
-	state.ctx = context.Background()
 
 }
 
@@ -199,6 +198,7 @@ func (s *scenarioState) beforeScenario(probeName string, gs *godog.Scenario) {
 	s.name = gs.Name
 	s.probe = summary.State.GetProbeLog(probeName)
 	s.audit = summary.State.GetProbeLog(probeName).InitializeAuditor(gs.Name, gs.Tags)
+	s.ctx = context.Background()
 	coreengine.LogScenarioStart(gs)
 }
 

--- a/service_packs/storage/azure/encryption_in_flight/encryption_in_flight.go
+++ b/service_packs/storage/azure/encryption_in_flight/encryption_in_flight.go
@@ -43,7 +43,6 @@ var Probe ProbeStruct
 func (state *scenarioState) setup() {
 
 	log.Println("[DEBUG] Setting up \"scenarioState\"")
-	state.ctx = context.Background()
 
 }
 
@@ -184,6 +183,7 @@ func (s *scenarioState) beforeScenario(probeName string, gs *godog.Scenario) {
 	s.name = gs.Name
 	s.probe = summary.State.GetProbeLog(probeName)
 	s.audit = summary.State.GetProbeLog(probeName).InitializeAuditor(gs.Name, gs.Tags)
+	s.ctx = context.Background()
 	coreengine.LogScenarioStart(gs)
 }
 


### PR DESCRIPTION
Fixing bug in storage service pack: state.ctx was nil in anAzureResourceGroupExists step function, causing an error in Azure SDK. Initialization was moved from BeforeSuite to BeforeScenario.