### PR TITLE
Removing unused fields from scenarioState struct for k8s probes

### DIFF
--- a/service_packs/kubernetes/iam/helpers.go
+++ b/service_packs/kubernetes/iam/helpers.go
@@ -22,14 +22,11 @@ import (
 )
 
 type scenarioState struct {
-	name           string
-	audit          *summary.ScenarioAudit
-	probe          *summary.Probe
-	httpStatusCode int
-	podName        string
-	podState       kubernetes.PodState
-	useDefaultNS   bool
-	wildcardRoles  interface{}
+	name         string
+	audit        *summary.ScenarioAudit
+	probe        *summary.Probe
+	podState     kubernetes.PodState
+	useDefaultNS bool
 }
 
 const (

--- a/service_packs/kubernetes/internet_access/helpers.go
+++ b/service_packs/kubernetes/internet_access/helpers.go
@@ -20,8 +20,6 @@ type scenarioState struct {
 	httpStatusCode int
 	podName        string
 	podState       kubernetes.PodState
-	useDefaultNS   bool
-	wildcardRoles  interface{}
 }
 
 func beforeScenario(s *scenarioState, probeName string, gs *godog.Scenario) {

--- a/service_packs/kubernetes/pod_security_policy/helpers.go
+++ b/service_packs/kubernetes/pod_security_policy/helpers.go
@@ -32,14 +32,10 @@ const (
 type PSPProbeCommand int
 
 type scenarioState struct {
-	name           string
-	audit          *summary.ScenarioAudit
-	probe          *summary.Probe
-	httpStatusCode int
-	podName        string
-	podState       kubernetes.PodState
-	useDefaultNS   bool
-	wildcardRoles  interface{}
+	name     string
+	audit    *summary.ScenarioAudit
+	probe    *summary.Probe
+	podState kubernetes.PodState
 }
 
 // PSPVerificationProbe encapsulates the command and expected result to be used in a Pod Security Policy probe.


### PR DESCRIPTION
Updates to the following probes:
- kubernetes/iam
- kubernetes/internet_access
- pod_security_policy

#172 