### PR TITLE
Centralizing all tags for a service pack

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,6 +25,16 @@ func (ctx *ConfigVars) GetTags() string {
 	return ctx.Tags
 }
 
+func SetTags(tags map[string][]string) {
+	configTags := strings.Split(Vars.GetTags(), ",")
+	for _, configTag := range configTags {
+		for _, tag := range tags[configTag] {
+			configTags = append(configTags, "@"+tag)
+		}
+	}
+	Vars.Tags = strings.Join(configTags, ",")
+}
+
 // Handle tag exclusions provided via the config vars file
 func (ctx *ConfigVars) handleTagExclusions() {
 	for _, tag := range ctx.TagExclusions {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,14 +25,14 @@ func (ctx *ConfigVars) GetTags() string {
 	return ctx.Tags
 }
 
-func SetTags(tags map[string][]string) {
-	configTags := strings.Split(Vars.GetTags(), ",")
+func (ctx *ConfigVars) SetTags(tags map[string][]string) {
+	configTags := strings.Split(ctx.GetTags(), ",")
 	for _, configTag := range configTags {
 		for _, tag := range tags[configTag] {
 			configTags = append(configTags, "@"+tag)
 		}
 	}
-	Vars.Tags = strings.Join(configTags, ",")
+	ctx.Tags = strings.Join(configTags, ",")
 }
 
 // Handle tag exclusions provided via the config vars file

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -147,6 +147,26 @@ func TestAddExclusion(t *testing.T) {
 	checkTagsContainExclusion(config, tag, t)
 }
 
+func TestSetTags(t *testing.T) {
+	vars, _ := NewConfig("")
+	tagName := "@probes/kubernetes"
+	tagID := "k-cra"
+	expected := 0
+	vars.Tags = tagName
+	tags := map[string][]string{tagName: []string{tagID}}
+	t.Log(tags)
+	vars.SetTags(tags)
+	for _, tag := range strings.Split(vars.Tags, ",") {
+		t.Log("Tag found:" + tag)
+		if tag == tagName || tag == "@"+tagID {
+			expected = expected + 1
+		}
+	}
+	if expected != 2 {
+		t.Errorf("Tag name and tag ID were not found in Vars.Tags")
+	}
+}
+
 // Pending... these may be too integration-y for a unit test
 func TestInit(t *testing.T)                       {}
 func TestValidateConfigPath(t *testing.T)         {}

--- a/service_packs/kubernetes/container_registry_access/container_registry_access.feature
+++ b/service_packs/kubernetes/container_registry_access/container_registry_access.feature
@@ -1,9 +1,3 @@
-@probes/kubernetes
-@standard/cis/gke/6
-@standard/cis/gke/6.1
-@standard/citihub/CHC2-APPDEV135
-@standard/citihub/CHC2-ITS120
-@csp/any
 @k-cra
 Feature: Protect image container registries
     As a Security Auditor

--- a/service_packs/kubernetes/container_registry_access/container_registry_access.feature
+++ b/service_packs/kubernetes/container_registry_access/container_registry_access.feature
@@ -1,10 +1,10 @@
 @probes/kubernetes
-@probes/kubernetes/container_registry_access
 @standard/cis/gke/6
 @standard/cis/gke/6.1
 @standard/citihub/CHC2-APPDEV135
 @standard/citihub/CHC2-ITS120
 @csp/any
+@k-cra
 Feature: Protect image container registries
     As a Security Auditor
     I want to ensure that containers image registries are secured in my organisation's Kubernetes clusters
@@ -12,20 +12,20 @@ Feature: Protect image container registries
 
     #Rule: CHC2-APPDEV135 - Ensure software release and deployment is managed through a formal, controlled process
 
-    @probes/kubernetes/container_registry_access/1.0 @control_type/preventative @standard/cis/gke/6.1.3
+    @k-cra-001
     Scenario: Ensure container image registries are read-only
         Given a Kubernetes cluster is deployed
         And I am authorised to pull from a container registry
         When I attempt to push to the container registry using the cluster identity
         Then the push request is rejected due to authorization
 
-    @probes/kubernetes/container_registry_access/1.1 @control_type/preventative @standard/cis/gke/6.1.4
+    @k-cra-002
     Scenario: Ensure deployment from an authorised container registry is allowed
         Given a Kubernetes cluster is deployed
         When a user attempts to deploy a container from an authorised registry
         Then the deployment attempt is allowed
 
-    @probes/kubernetes/container_registry_access/1.2 @control_type/preventative @standard/cis/gke/6.1.5
+    @k-cra-003
     Scenario: Ensure deployment from an unauthorised container registry is denied
         Given a Kubernetes cluster is deployed
         When a user attempts to deploy a container from an unauthorised registry

--- a/service_packs/kubernetes/pack/pack.go
+++ b/service_packs/kubernetes/pack/pack.go
@@ -11,7 +11,7 @@ import (
 )
 
 func GetProbes() []coreengine.Probe {
-	config.SetTags(tags)
+	config.Vars.SetTags(tags)
 	if config.Vars.ServicePacks.Kubernetes.IsExcluded() {
 		return nil
 	}

--- a/service_packs/kubernetes/pack/pack.go
+++ b/service_packs/kubernetes/pack/pack.go
@@ -11,6 +11,7 @@ import (
 )
 
 func GetProbes() []coreengine.Probe {
+	config.SetTags(tags)
 	if config.Vars.ServicePacks.Kubernetes.IsExcluded() {
 		return nil
 	}

--- a/service_packs/kubernetes/pack/tags.go
+++ b/service_packs/kubernetes/pack/tags.go
@@ -1,0 +1,17 @@
+package kubernetes_pack
+
+var (
+	tags = map[string][]string{
+		"@probes/kubernetes":                           []string{"k-cra"},
+		"@standard/citihub/CHC2-APPDEV135":             []string{"k-cra"},
+		"@standard/citihub/CHC2-ITS120":                []string{"k-cra"},
+		"@control_type/preventative":                   []string{"k-cra-001", "k-cra-002", "k-cra-003"},
+		"@standard/cis/gke/6":                          []string{"k-cra"},
+		"@standard/cis/gke/6.1":                        []string{"k-cra"},
+		"@standard/cis/gke/6.1.3":                      []string{"k-cra-001"},
+		"@standard/cis/gke/6.1.4":                      []string{"k-cra-002"},
+		"@standard/cis/gke/6.1.5":                      []string{"k-cra-003"},
+		"@csp/any":                                     []string{"k-cra"},
+		"@probes/kubernetes/container_registry_access": []string{"k-cra"},
+	}
+)


### PR DESCRIPTION
This is a prototyped change, and will need to be implemented across the rest of the k8s and storage service packs.

Additionally, this logic will leave a gap that needs to be addressed: Cucumber output will now show the tags differently than it did in the past, which is not ideal.