### PR TITLE
Correcting for bug in config exclusions

### DIFF
--- a/service_packs/kubernetes/container_registry_access/container_registry_access.feature
+++ b/service_packs/kubernetes/container_registry_access/container_registry_access.feature
@@ -1,4 +1,5 @@
 @k-cra
+@probes/kubernetes/container_registry_access
 Feature: Protect image container registries
     As a Security Auditor
     I want to ensure that containers image registries are secured in my organisation's Kubernetes clusters

--- a/service_packs/kubernetes/general/general.feature
+++ b/service_packs/kubernetes/general/general.feature
@@ -1,4 +1,5 @@
 @k-gen
+@probes/kubernetes/general
 Feature: General Cluster Security Configurations
     As a Security Auditor
     I want to ensure that Kubernetes clusters have general security configurations in place

--- a/service_packs/kubernetes/iam/iam.feature
+++ b/service_packs/kubernetes/iam/iam.feature
@@ -1,4 +1,5 @@
 @k-iam
+@probes/kubernetes/iam
 Feature: Ensure stringent authentication and authorisation
     As a Security Auditor
     I want to ensure that stringent authentication and authorisation policies are applied to my organisation's Kubernetes clusters

--- a/service_packs/kubernetes/internet_access/internet_access.feature
+++ b/service_packs/kubernetes/internet_access/internet_access.feature
@@ -1,4 +1,5 @@
 @k-iaf
+@probes/kubernetes/internet_access
 Feature: Egress control of a kubernetes cluster
     As a Security Auditor
     I want to ensure that containers running inside Kubernetes clusters cannot directly access the Internet


### PR DESCRIPTION
We got excited about centralizing tags last week, and allowed ourselves to overlook the role tags are playing in our config exclusion handling. This returns the necessary tags to restore expected behavior.