### PR TITLE
Adding setting for single output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -247,8 +247,7 @@ node_modules
 __debug_bin
 
 # probr misc ('probr' is Linux exe)
-cucumber_output
-audit_output
+probr_output
 !examples/*
 probr
 static-content/

--- a/README.md
+++ b/README.md
@@ -82,12 +82,11 @@ These are general configuration variables.
 |VarsFile|Config YAML File Path|yes|N/A|N/A|N/A|
 |Silent|Disable visual runtime indicator|yes|no|N/A|false|
 |NoSummary|Flag to switch off summary output|yes|no|N/A|false|
-|CucumberDir|Path to cucumber output dir if applicable|yes|yes|PROBR_CUCUMBER_DIR|cucumber_output|
+|WriteDirectory|Path to all output, including audit, cucumber results and other temp files|yes|yes|PROBR_WRITE_DIRECTORY|probr_output|
 |Tags|Feature tag inclusions and exclusions|yes|yes|PROBR_TAGS| |
 |LogLevel|Set log verbosity level|yes|yes|PROBR_LOG_LEVEL|ERROR|
 |OutputType|"IO" will write to file, as is needed for CLI usage. "INMEM" should be used in non-CLI cases, where values should be returned in-memory instead|no|yes|PROBR_OUTPUT_TYPE|IO|
 |AuditEnabled|Flag to switch on audit log|no|yes|PROBR_AUDIT_ENABLED|true|
-|AuditDir|Path to audit dir|no|yes|PROBR_AUDIT_DIR|audit_output|
 |OverwriteHistoricalAudits|Flag to allow audit overwriting|no|yes|OVERWRITE_AUDITS|true|
 |ContainerRegistry|Probe image container registry|no|yes|PROBR_CONTAINER_REGISTRY|docker.io|
 |ProbeImage|Probe image name|no|probeImage|PROBR_PROBE_IMAGE|citihub/probr-probe|

--- a/cmd/cli_flags/flags.go
+++ b/cmd/cli_flags/flags.go
@@ -27,7 +27,7 @@ func HandleFlags() {
 	stringFlag("varsfile", "path to config file", varsFileHandler)
 	stringFlag("loglevel", "set log level", loglevelHandler)
 	stringFlag("kubeconfig", "kube config file", kubeConfigHandler)
-	stringFlag("cucumberdir", "cucumber output directory", cucumberDirHandler)
+	stringFlag("writedirectory", "output directory", writeDirHandler)
 	stringFlag("tags", "feature tags to include or exclude", tagsHandler)
 	boolFlag("silent", "disable visual runtime indicator, useful for CI tasks", silentHandler)
 	boolFlag("nosummary", "switch off summary output", nosummaryHandler)
@@ -74,11 +74,11 @@ func varsFileHandler(v interface{}) {
 	}
 }
 
-// cucumberDirHandler
-func cucumberDirHandler(v interface{}) {
+// writeDirHandler
+func writeDirHandler(v interface{}) {
 	if len(*v.(*string)) > 0 {
 		log.Printf("[NOTICE] Output Directory has been overridden via command line")
-		config.Vars.CucumberDir = *v.(*string)
+		config.Vars.WriteDirectory = *v.(*string)
 	}
 }
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -51,7 +51,7 @@ func main() {
 	if out == nil || len(out) == 0 {
 		summary.State.Meta["no probes completed"] = fmt.Sprintf(
 			"Probe results not written to file, possibly due to all being excluded or permissions on the specified output directory: %s",
-			config.Vars.CucumberDir,
+			config.CucumberDir(),
 		)
 	}
 	summary.State.PrintSummary()

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -1,7 +1,6 @@
 # Empty and omitted keys will use default values
 AuditEnabled: true
-AuditDir: audit_output
-CucumberDir: cucumber_output
+WriteDirectory: probr_output
 OverwriteHistoricalAudits: true
 ServicePacks:
   Kubernetes:

--- a/internal/config/README.md
+++ b/internal/config/README.md
@@ -33,7 +33,6 @@ When creating new config vars, remember to do the following:
 
 1. Add an entry to the struct `ConfigVars` in `internal/config/config.go`
 1. Add an entry (matching the config vars struct) to `setEnvOrDefaults` in `internal/config/defaults.go`
-1. Add logic (matching the defaults entry) to `internal/config/getters.go`
 1. If appropriate, add logic to `cmd/probr-cli/flags.go`
 
 By following the above steps, you will have accomplished the following:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 
@@ -112,9 +113,24 @@ func LogConfigState() {
 	log.Printf("[NOTICE] Config State: %s", s)
 }
 
+// AuditDir creates -audit- directory within WriteDirectory
 func AuditDir() string {
-	_ = os.Mkdir(Vars.AuditDir, 0755) // Creates if not already existing
-	return Vars.AuditDir
+	auditDir := filepath.Join(WriteDirectory(), "audit")
+	_ = os.Mkdir(auditDir, 0755) // Creates if not already existing
+	return auditDir
+}
+
+// CucumberDir creates -cucumber- directory within WriteDirectory
+func CucumberDir() string {
+	cucumberDir := filepath.Join(WriteDirectory(), "cucumber")
+	_ = os.Mkdir(cucumberDir, 0755) // Creates if not already existing
+	return cucumberDir
+}
+
+// WriteDirectory creates the output folder specified in settings
+func WriteDirectory() string {
+	_ = os.Mkdir(Vars.WriteDirectory, 0755) // Creates if not already existing
+	return Vars.WriteDirectory
 }
 
 func (ctx *ConfigVars) handleConfigFileExclusions() {

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -13,8 +13,7 @@ func setFromEnvOrDefaults(e *ConfigVars) {
 	e.set(&e.Tags, "PROBR_TAGS", "")
 	e.set(&e.AuditEnabled, "PROBR_AUDIT_ENABLED", "true")
 	e.set(&e.OutputType, "PROBR_OUTPUT_TYPE", "IO")
-	e.set(&e.CucumberDir, "PROBR_CUCUMBER_DIR", "cucumber_output")
-	e.set(&e.AuditDir, "PROBR_AUDIT_DIR", "audit_output")
+	e.set(&e.WriteDirectory, "PROBR_WRITE_DIRECTORY", "probr_output")
 	e.set(&e.LogLevel, "PROBR_LOG_LEVEL", "ERROR")
 	e.set(&e.OverwriteHistoricalAudits, "OVERWRITE_AUDITS", "true")
 

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -6,8 +6,7 @@ type ConfigVars struct {
 	ServicePacks              ServicePacks   `yaml:"ServicePacks"`
 	CloudProviders            CloudProviders `yaml:"CloudProviders"`
 	OutputType                string         `yaml:"OutputType"`
-	CucumberDir               string         `yaml:"CucumberDir"`
-	AuditDir                  string         `yaml:"AuditDir"`
+	WriteDirectory            string         `yaml:"WriteDirectory"`
 	AuditEnabled              string         `yaml:"AuditEnabled"`
 	LogLevel                  string         `yaml:"LogLevel"`
 	OverwriteHistoricalAudits string         `yaml:"OverwriteHistoricalAudits"`

--- a/internal/coreengine/probe_helpers.go
+++ b/internal/coreengine/probe_helpers.go
@@ -24,6 +24,9 @@ const rootDirName = "probr"
 
 var outputDir *string
 
+// This variable points to the function. It is used in oder to be able to mock config.CucumberDir() function during testing. See TestGetOutputPath.
+var cucumberDirFunc = config.CucumberDir
+
 // getRootDir gets the root directory of the probr executable.
 func getRootDir() (string, error) {
 	//TODO: fix this!! think it's a tad dodgy!
@@ -55,11 +58,9 @@ func getRootDir() (string, error) {
 // plus the test name supplied
 func getOutputPath(t string) (*os.File, error) {
 
-	_ = os.Mkdir(config.Vars.CucumberDir, 0755)
-
-	//filename is test name (supplied) + .json
+	////filename is test name (supplied) + .json
 	fn := t + ".json"
-	return os.Create(filepath.Join(config.Vars.CucumberDir, fn))
+	return os.Create(filepath.Join(cucumberDirFunc(), fn))
 }
 
 func GetFeaturePath(path ...string) string {

--- a/internal/coreengine/probe_helpers_test.go
+++ b/internal/coreengine/probe_helpers_test.go
@@ -21,7 +21,11 @@ func TestGetRootDir(t *testing.T) {
 
 func TestGetOutputPath(t *testing.T) {
 	var file *os.File
-	d := filepath.Join(t.TempDir(), "test_output_dir") //Using t.TempDir() to ensure built-in test directory is automatically removed by cleanup when test and subtests complete. See: https://golang.org/pkg/testing/#pkg-subdirectories
+
+	// Using -testdata- folder to ensure no test resources are included in build
+	// Once we migrate to go v1.15, we should use t.TempDir() to ensure built-in test directory is automatically removed by cleanup when test and subtests complete. See: https://golang.org/pkg/testing/#pkg-subdirectories
+	d := filepath.Join("testdata", "test_output_dir")
+
 	f := "test_file"
 	desiredFile := filepath.Join(d, f) + ".json"
 	defer func() {
@@ -43,12 +47,14 @@ func TestGetOutputPath(t *testing.T) {
 	}()
 	// Faking result for config.CucumberDir(). This is used inside getOutputPath.
 	cucumberDirFunc = func() string {
-		_ = os.Mkdir(d, 0755) // Creates if not already existing
+		_ = os.MkdirAll(d, 0755) // Creates if not already existing
 		return d
 	}
-	file, _ = getOutputPath(f)
+	var e error
+	file, e = getOutputPath(f)
 	if desiredFile != file.Name() {
 		t.Logf("Desired filepath '%s' does not match '%s'", desiredFile, file.Name())
+		t.Log(e)
 		t.Fail()
 	}
 }


### PR DESCRIPTION
- Added new config setting for WriteDirectory. Enabled support for config file, env var and cli flag.
- Removed config settings for AuditDir and CucumberDir.
- Preserved config.AuditDir() and config.CucumberDir(), adding respective folders under WriteDirectory
- Added unit tests for testing new cli flag
- Refactored unit test for getOutputPath
- Updated readme files:
  - Removed references to AuditDir and CucumberDir
  - Added reference to WriteDirectory
  - Removed reference to getters.go
- Updated gitignore
  - Removed audit_output and cucumber_output
  - Added probr_output

For manual and integration testing, see test plan in original issue

Closes #223