### PR TITLE
Fixing bug with abs path in TestReadStaticFile - Only happens when ru…

### DIFF
--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -94,7 +94,11 @@ func ReadStaticFile(path ...string) ([]byte, error) {
 	for _, folder := range dirpathSlice {
 		dirPath = filepath.Join(dirPath, folder)
 	}
-	filepath := filepath.Join("/", dirPath, filename) //Need the abs path (/) for pgker to work
+	if !filepath.IsAbs(dirPath) {
+		dirPath = filepath.Join("/", dirPath) //Need the abs path (/) for pgker to work
+	}
+
+	filepath := filepath.Join(dirPath, filename)
 
 	// If pkged.go file has been generated using pkger cli tool, this will open the file from bundled memory buffer.
 	// Otherwise, this will read from file system

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -144,7 +144,7 @@ func TestReadStaticFile(t *testing.T) {
 	}
 	testSubFolder := "testdata_subfolder"
 	testFileName := "psp-azp-privileges.yaml"
-	testFilePath := filepath.Join("/", testFolder, testFileName)
+	testFilePath := filepath.Join(testFolder, testFileName)
 	testFileContent, fileError := ioutil.ReadFile(testFilePath)
 	if fileError != nil {
 		t.Fatalf("Error loading test data: %v", fileError)


### PR DESCRIPTION
Fixing bug with abs path in TestReadStaticFile - Only happens when running unit tests locally in Windows.

Relates to #216