### PR TITLE
Refactoring config.go, adding pointer receivers to AuditDir(), Cucumb…

### DIFF
--- a/cmd/cli_flags/flags_test.go
+++ b/cmd/cli_flags/flags_test.go
@@ -1,0 +1,45 @@
+package cli_flags
+
+import (
+	"os"
+	"testing"
+
+	"github.com/citihub/probr/internal/config"
+)
+
+func TestHandleFlags(t *testing.T) {
+
+	// Note:
+	// This test is only verifying WriteDirectory cli flag.
+	// It could be extended to test other flags, or all. If so, it should be refactored to avoid code duplication. Keeping it simple for now (YAGNI).
+
+	tests := []struct {
+		testName                  string
+		addCliFlag                string
+		expectedResultInConfigVar string
+	}{
+		{
+			testName:                  "HandleFlag_WithCliFlag_ShouldAddCliFlagValueToGlobalConfig",
+			addCliFlag:                "-writedirectory=newdirectoryfromcliflag",
+			expectedResultInConfigVar: "newdirectoryfromcliflag",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+
+			// Simulating cli arguments
+			os.Args = append(os.Args, "-writedirectory=newdirectoryfromcliflag")
+
+			// This function is expected to modify global configVar object, setting values based on tags
+			// It cannot be called more than once, since global flag object is used and it would raise a "flag redefined" error.
+			// An alternative for a potential refactoring is to use FlagSet instead. See: https://stackoverflow.com/questions/24504024/defining-independent-flagsets-in-golang
+			HandleFlags()
+
+			//Check WriteDirectory was set in global ConfigVars
+			if config.Vars.WriteDirectory != tt.expectedResultInConfigVar {
+				t.Errorf("HandleFlags(); config.Vars.WiteDirectory = %v, Expected: %v", config.Vars.WriteDirectory, tt.expectedResultInConfigVar)
+				return
+			}
+		})
+	}
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -51,7 +51,7 @@ func main() {
 	if out == nil || len(out) == 0 {
 		summary.State.Meta["no probes completed"] = fmt.Sprintf(
 			"Probe results not written to file, possibly due to all being excluded or permissions on the specified output directory: %s",
-			config.CucumberDir(),
+			config.Vars.CucumberDir(),
 		)
 	}
 	summary.State.PrintSummary()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -113,24 +113,24 @@ func LogConfigState() {
 	log.Printf("[NOTICE] Config State: %s", s)
 }
 
-// AuditDir creates -audit- directory within WriteDirectory
-func AuditDir() string {
-	auditDir := filepath.Join(WriteDirectory(), "audit")
+// AuditDir creates and returns -audit- directory within WriteDirectory
+func (ctx *ConfigVars) AuditDir() string {
+	auditDir := filepath.Join(ctx.GetWriteDirectory(), "audit")
 	_ = os.Mkdir(auditDir, 0755) // Creates if not already existing
 	return auditDir
 }
 
-// CucumberDir creates -cucumber- directory within WriteDirectory
-func CucumberDir() string {
-	cucumberDir := filepath.Join(WriteDirectory(), "cucumber")
+// CucumberDir creates and returns -cucumber- directory within WriteDirectory
+func (ctx *ConfigVars) CucumberDir() string {
+	cucumberDir := filepath.Join(ctx.GetWriteDirectory(), "cucumber")
 	_ = os.Mkdir(cucumberDir, 0755) // Creates if not already existing
 	return cucumberDir
 }
 
-// WriteDirectory creates the output folder specified in settings
-func WriteDirectory() string {
-	_ = os.Mkdir(Vars.WriteDirectory, 0755) // Creates if not already existing
-	return Vars.WriteDirectory
+// GetWriteDirectory creates and returns the output folder specified in settings
+func (ctx *ConfigVars) GetWriteDirectory() string {
+	_ = os.Mkdir(ctx.WriteDirectory, 0755) // Creates if not already existing
+	return ctx.WriteDirectory
 }
 
 func (ctx *ConfigVars) handleConfigFileExclusions() {

--- a/internal/config/defaults_test.go
+++ b/internal/config/defaults_test.go
@@ -1,0 +1,63 @@
+package config
+
+import (
+	"os"
+	"testing"
+)
+
+func Test_setFromEnvOrDefaults(t *testing.T) {
+
+	// Note:
+	// This test is only verifying WriteDirectory.
+	// It could be extended to test other config vars, or all. If so, it should be refactored to avoid code duplication. Keeping it simple for now (YAGNI).
+
+	envVarCurrentValuePROBR_WRITE_DIRECTORY := os.Getenv("PROBR_WRITE_DIRECTORY") // Used to restore env to original state after test
+	defer func() {
+		os.Setenv("PROBR_WRITE_DIRECTORY", envVarCurrentValuePROBR_WRITE_DIRECTORY)
+	}()
+	defaultValuePROBR_WRITE_DIRECTORY := "probr_output"
+	envVarValuePROBR_WRITE_DIRECTORY := "ValueFromEnvVar_WriteDirectory"
+
+	type args struct {
+		e *ConfigVars
+	}
+	tests := []struct {
+		testName                     string
+		testArgs                     args
+		setEnvVar                    bool
+		expectedResultWriteDirectory string
+	}{
+		{
+			testName:                     "setFromEnvOrDefaults_GivenEnvVar_ShouldSetConfigVarToEnvVarValue",
+			testArgs:                     args{e: &ConfigVars{}},
+			setEnvVar:                    true,
+			expectedResultWriteDirectory: envVarValuePROBR_WRITE_DIRECTORY,
+		},
+		{
+			testName:                     "setFromEnvOrDefaults_WithoutEnvVar_ShouldSetConfigVarToDefaultValue",
+			testArgs:                     args{e: &ConfigVars{}},
+			setEnvVar:                    false,
+			expectedResultWriteDirectory: defaultValuePROBR_WRITE_DIRECTORY,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+
+			//Based on test case, modify env vars
+			if tt.setEnvVar {
+				os.Setenv("PROBR_WRITE_DIRECTORY", envVarValuePROBR_WRITE_DIRECTORY)
+			} else {
+				os.Setenv("PROBR_WRITE_DIRECTORY", "")
+			}
+
+			setFromEnvOrDefaults(tt.testArgs.e) //This function will modify config object
+
+			//Check WriteDirectory
+			if tt.testArgs.e.WriteDirectory != tt.expectedResultWriteDirectory {
+				t.Errorf("setFromEnvOrDefaults(); PROBR_WRITE_DIRECTORY = %v, Expected: %v", tt.testArgs.e.WriteDirectory, tt.expectedResultWriteDirectory)
+				return
+			}
+
+		})
+	}
+}

--- a/internal/coreengine/probe_helpers.go
+++ b/internal/coreengine/probe_helpers.go
@@ -25,7 +25,7 @@ const rootDirName = "probr"
 var outputDir *string
 
 // This variable points to the function. It is used in oder to be able to mock config.CucumberDir() function during testing. See TestGetOutputPath.
-var cucumberDirFunc = config.CucumberDir
+var cucumberDirFunc = config.Vars.CucumberDir
 
 // getRootDir gets the root directory of the probr executable.
 func getRootDir() (string, error) {

--- a/internal/coreengine/probe_helpers_test.go
+++ b/internal/coreengine/probe_helpers_test.go
@@ -30,7 +30,7 @@ func TestGetOutputPath(t *testing.T) {
 	desiredFile := filepath.Join(d, f) + ".json"
 	defer func() {
 
-		cucumberDirFunc = config.CucumberDir //Restoring to original function after test
+		cucumberDirFunc = config.Vars.CucumberDir //Restoring to original function after test
 
 		// Cleanup test assets
 		file.Close()

--- a/internal/summary/summary.go
+++ b/internal/summary/summary.go
@@ -76,7 +76,7 @@ func (s *SummaryState) LogPodName(n string) {
 
 func (s *SummaryState) initProbe(n string) {
 	if s.Probes[n] == nil {
-		ap := filepath.Join(config.AuditDir(), (n + ".json")) // Needed in both Probe and ProbeAudit
+		ap := filepath.Join(config.Vars.AuditDir(), (n + ".json")) // Needed in both Probe and ProbeAudit
 		s.Probes[n] = &Probe{
 			name:          n,
 			Meta:          make(map[string]interface{}),

--- a/internal/summary/summary_test.go
+++ b/internal/summary/summary_test.go
@@ -50,7 +50,7 @@ func createSummaryStateWithMockProbe(probename string) SummaryState {
 	sumstate.Probes = make(map[string]*Probe)
 	sumstate.Meta = make(map[string]interface{})
 	sumstate.Meta["names of pods created"] = []string{}
-	ap := filepath.Join(config.AuditDir(), (probename + ".json")) // Needed in both Probe and ProbeAudit
+	ap := filepath.Join(config.Vars.AuditDir(), (probename + ".json")) // Needed in both Probe and ProbeAudit
 	sumstate.Probes[probename] = &Probe{
 		name:          probename,
 		Meta:          make(map[string]interface{}),


### PR DESCRIPTION
- Refactoring _config.go_: adding pointer receivers to `AuditDir()`, `CucumberDir() `and `GetWriteDirectory()` functions.
This addresses @eddie-knight [feedback](https://github.com/citihub/probr/pull/228#discussion_r566856186) on PR #228 


- Adding unit tests for _defaults_ and _flags_.
