### PR TITLE
Updating logic to delete empty cucumber output files, adding file.Clo…

### DIFF
--- a/internal/coreengine/feature_probe_handler.go
+++ b/internal/coreengine/feature_probe_handler.go
@@ -28,9 +28,9 @@ func toFileGodogProbeHandler(gd *GodogProbe) (int, *bytes.Buffer, error) {
 	if err != nil {
 		return -1, nil, err
 	}
+
 	status, err := runTestSuite(o, gd)
 
-	//TODO - review!
 	//FUDGE! If the tests are skipped due to tags, then an empty file may
 	//be left lingering.  This will have a non-zero size as we've actually
 	//had to create the file prior to the test run (see line 31).  If it's
@@ -38,7 +38,7 @@ func toFileGodogProbeHandler(gd *GodogProbe) (int, *bytes.Buffer, error) {
 	//and can be removed.
 	i, err := o.Stat()
 	s := i.Size()
-
+	o.Close()
 	if s < 4 {
 		err = os.Remove(o.Name())
 		if err != nil {

--- a/service_packs/kubernetes/pod_security_policy/pod_security_policy.go
+++ b/service_packs/kubernetes/pod_security_policy/pod_security_policy.go
@@ -125,7 +125,7 @@ func (s *scenarioState) runVerificationProbe(c VerificationProbe) error {
 			err = utils.ReformatError("%s: %v - (%v)", utils.CallerName(0), c, res.Err)
 			log.Print(err)
 			return err
-		}
+		} // TODO: Potential bug: (res.Err != nil && res.Internal == false) not handled. E.g: Try to execute 'sudo chroot'.
 
 		//we've managed to execution against the cluster.  This may have failed due to pod security, but this
 		//is still a 'successful' execution.  The exit code of the command needs to be verified against expected


### PR DESCRIPTION
- Updating logic to delete empty cucumber output files, adding file.Close().
- Added comment about potential bug somewhere else.

Closes #235 