### PR TITLE
Moved 'internal/azureutil' to storage service pack

### DIFF
--- a/internal/clouddriver/azure/azsecuritypolicyprovider.go
+++ b/internal/clouddriver/azure/azsecuritypolicyprovider.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/resources/mgmt/policy"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
-	"github.com/citihub/probr/service_packs/storage/azure"
+	azureutil "github.com/citihub/probr/service_packs/storage/azure"
 )
 
 type azPolicy struct {
@@ -164,7 +164,7 @@ func (p *AZSecurityPolicyProvider) getPolicies() (*map[string]*azPolicy, error) 
 		return &p.policiesByType, nil
 	}
 
-	s := azure.SubscriptionID()
+	s := azureutil.SubscriptionID()
 	log.Printf("[INFO] Using Azure Sub: %v", s)
 
 	scope := "/subscriptions/" + s

--- a/internal/clouddriver/azure/azsecuritypolicyprovider.go
+++ b/internal/clouddriver/azure/azsecuritypolicyprovider.go
@@ -1,0 +1,220 @@
+package azure
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/profiles/latest/resources/mgmt/policy"
+	"github.com/Azure/go-autorest/autorest/azure/auth"
+	"github.com/citihub/probr/service_packs/storage/azure"
+)
+
+type azPolicy struct {
+	scope       *string
+	policyType  *string
+	displayName *string
+	uuid        *string
+}
+
+//AZSecurityPolicyProvider queries the policies applied on the supplied subscription and resource group.  This may be deprecated in favour
+//of azk8sconstrainttemplate which queries the kubernetes cluster directly.
+//TODO: decide if this should be kept.
+type AZSecurityPolicyProvider struct {
+	policiesByType map[string]*azPolicy
+}
+
+const (
+	azPSPLinuxRestricted              = "AZPSPLinuxRestricted"
+	azPSPContainerImage               = "AZPSPContainerImage"
+	azPSPContainerPrivilegeEscalation = "AZPSPContainerPrivilegeEscalation"
+	azPSPHostPIDHostIPCNS             = "AZPSPHostPIDHostIPCNS"
+	azPSPContainerPrivileged          = "AZPSPContainerPrivileged"
+	azPSPApprovedUsersAndGroups       = "AZPSPApprovedUsersAndGroups"
+	azPSPAllowedCapabilitiesOnly      = "AZPSPAllowedCapabilitiesOnly"
+	azPSPApprovedPortRangeOnly        = "AZPSPApprovedPortRangeOnly"
+	azPSPApprovedVolumeTypeOnly       = "AZPSPApprovedVolumeTypeOnly"
+	azPSPApprovedSeccompProfile       = "AZPSPApprovedSeccompProfile"
+)
+
+var azPolicyUUIDToProbrPolicy = make(map[string]string)
+
+func init() {
+	//TODO: should really map these to types, but not sure of the how important this is, ie. is it sufficient to say "some polices"?
+	azPolicyUUIDToProbrPolicy["/providers/Microsoft.Authorization/policySetDefinitions/42b8ef37-b724-4e24-bbc8-7a7708edfe00"] = azPSPLinuxRestricted
+	azPolicyUUIDToProbrPolicy["/providers/Microsoft.Authorization/policyDefinitions/febd0533-8e55-448f-b837-bd0e06f16469"] = azPSPContainerImage
+	azPolicyUUIDToProbrPolicy["/providers/Microsoft.Authorization/policyDefinitions/1c6e92c9-99f0-4e55-9cf2-0c234dc48f99"] = azPSPContainerPrivilegeEscalation
+	azPolicyUUIDToProbrPolicy["/providers/Microsoft.Authorization/policyDefinitions/47a1ee2f-2a2a-4576-bf2a-e0e36709c2b8"] = azPSPHostPIDHostIPCNS
+	azPolicyUUIDToProbrPolicy["/providers/Microsoft.Authorization/policyDefinitions/95edb821-ddaf-4404-9732-666045e056b4"] = azPSPContainerPrivileged
+	azPolicyUUIDToProbrPolicy["/providers/Microsoft.Authorization/policyDefinitions/f06ddb64-5fa3-4b77-b166-acb36f7f6042"] = azPSPApprovedUsersAndGroups
+	azPolicyUUIDToProbrPolicy["/providers/Microsoft.Authorization/policyDefinitions/c26596ff-4d70-4e6a-9a30-c2506bd2f80c"] = azPSPAllowedCapabilitiesOnly
+	azPolicyUUIDToProbrPolicy["/providers/Microsoft.Authorization/policyDefinitions/82985f06-dc18-4a48-bc1c-b9f4f0098cfe"] = azPSPApprovedPortRangeOnly
+	azPolicyUUIDToProbrPolicy["/providers/Microsoft.Authorization/policyDefinitions/16697877-1118-4fb1-9b65-9898ec2509ec"] = azPSPApprovedVolumeTypeOnly
+	azPolicyUUIDToProbrPolicy["/providers/Microsoft.Authorization/policyDefinitions/975ce327-682c-4f2e-aa46-b9598289b86c"] = azPSPApprovedSeccompProfile
+}
+
+//NewAzPolicyProvider ...
+func NewAzPolicyProvider() *AZSecurityPolicyProvider {
+	return &AZSecurityPolicyProvider{
+		policiesByType: make(map[string]*azPolicy),
+	}
+}
+
+// HasSecurityPolicies ...
+func (p *AZSecurityPolicyProvider) HasSecurityPolicies() (*bool, error) {
+	pc, err := p.getPolicies()
+
+	if err != nil {
+		return nil, err
+	}
+
+	b := len(*pc) > 0
+
+	return &b, nil
+}
+
+// HasPrivilegedAccessRestriction ...
+func (p *AZSecurityPolicyProvider) HasPrivilegedAccessRestriction() (*bool, error) {
+	return p.checkForRestrictions(&[]string{azPSPLinuxRestricted, azPSPContainerPrivileged})
+}
+
+// For the following, the hostPID, hostIPC and hostNetwork restrictions are wrapped together
+// in Azure policies.  This is either in the general 'Linux Restricted' policy set or in the
+// HostPID/HostIPC/HostNetwork policy:
+
+// HasHostPIDRestriction ...
+func (p *AZSecurityPolicyProvider) HasHostPIDRestriction() (*bool, error) {
+	return p.checkForRestrictions(&[]string{azPSPLinuxRestricted, azPSPHostPIDHostIPCNS})
+}
+
+// HasHostIPCRestriction ...
+func (p *AZSecurityPolicyProvider) HasHostIPCRestriction() (*bool, error) {
+	return p.checkForRestrictions(&[]string{azPSPLinuxRestricted, azPSPHostPIDHostIPCNS})
+}
+
+// HasHostNetworkRestriction ...
+func (p *AZSecurityPolicyProvider) HasHostNetworkRestriction() (*bool, error) {
+	return p.checkForRestrictions(&[]string{azPSPLinuxRestricted, azPSPHostPIDHostIPCNS})
+}
+
+// HasAllowPrivilegeEscalationRestriction ...
+func (p *AZSecurityPolicyProvider) HasAllowPrivilegeEscalationRestriction() (*bool, error) {
+	return p.checkForRestrictions(&[]string{azPSPLinuxRestricted, azPSPContainerPrivilegeEscalation})
+}
+
+// HasRootUserRestriction ...
+func (p *AZSecurityPolicyProvider) HasRootUserRestriction() (*bool, error) {
+	return p.checkForRestrictions(&[]string{azPSPLinuxRestricted, azPSPApprovedUsersAndGroups})
+}
+
+// HasNETRAWRestriction ...
+func (p *AZSecurityPolicyProvider) HasNETRAWRestriction() (*bool, error) {
+	return p.checkForRestrictions(&[]string{azPSPLinuxRestricted})
+}
+
+// HasAllowedCapabilitiesRestriction ...
+func (p *AZSecurityPolicyProvider) HasAllowedCapabilitiesRestriction() (*bool, error) {
+	return p.checkForRestrictions(&[]string{azPSPLinuxRestricted, azPSPAllowedCapabilitiesOnly})
+}
+
+// HasAssignedCapabilitiesRestriction ...
+func (p *AZSecurityPolicyProvider) HasAssignedCapabilitiesRestriction() (*bool, error) {
+	return p.checkForRestrictions(&[]string{azPSPLinuxRestricted})
+}
+
+// HasHostPortRestriction ...
+func (p *AZSecurityPolicyProvider) HasHostPortRestriction() (*bool, error) {
+	return p.checkForRestrictions(&[]string{azPSPLinuxRestricted, azPSPApprovedPortRangeOnly})
+}
+
+// HasVolumeTypeRestriction ...
+func (p *AZSecurityPolicyProvider) HasVolumeTypeRestriction() (*bool, error) {
+	return p.checkForRestrictions(&[]string{azPSPLinuxRestricted, azPSPApprovedPortRangeOnly})
+}
+
+// HasSeccompProfileRestriction ...
+func (p *AZSecurityPolicyProvider) HasSeccompProfileRestriction() (*bool, error) {
+	return p.checkForRestrictions(&[]string{azPSPLinuxRestricted, azPSPApprovedPortRangeOnly})
+}
+
+func (p *AZSecurityPolicyProvider) checkForRestrictions(res *[]string) (*bool, error) {
+	pc, err := p.getPolicies()
+
+	if err != nil {
+		return nil, err
+	}
+
+	//check for the policies we've been given
+	for _, r := range *res {
+		_, b := (*pc)[r]
+		if b {
+			return &b, nil
+		}
+	}
+
+	//haven't found any if we get to here ...
+	b := false
+	return &b, nil
+}
+
+func (p *AZSecurityPolicyProvider) getPolicies() (*map[string]*azPolicy, error) {
+
+	if len(p.policiesByType) > 0 {
+		//already got 'em
+		return &p.policiesByType, nil
+	}
+
+	s := azure.SubscriptionID()
+	log.Printf("[INFO] Using Azure Sub: %v", s)
+
+	scope := "/subscriptions/" + s
+	log.Printf("[DEBUG] Getting Policy Assignment with subscriptionID: %v", scope)
+
+	ac := assignmentClient(s)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	l, err := ac.List(ctx, "")
+
+	if err != nil {
+		log.Printf("[ERROR] Error getting Azure Policies: %v", err)
+		return nil, err
+	}
+
+	alr := l.Response()
+	// convert the AZ representation into something sensible ..
+	for _, r := range *alr.Value {
+		azp := azPolicy{}
+
+		//TODO: also map the type here
+		azp.uuid = r.AssignmentProperties.PolicyDefinitionID //name in azure policy is the uuid
+		azp.displayName = r.AssignmentProperties.DisplayName //display name == 'name'
+		azp.scope = r.AssignmentProperties.Scope
+
+		log.Printf("[DEBUG] azPolicy %v %v %v", *azp.uuid, *azp.displayName, *azp.scope)
+
+		//look up the "type" based on the uuid of the policy
+		t, exists := azPolicyUUIDToProbrPolicy[*azp.uuid]
+		if !exists {
+			//set t to a default type
+			t = "AZPSPUnknown"
+		}
+
+		p.policiesByType[t] = &azp
+	}
+
+	return &p.policiesByType, nil
+}
+
+func assignmentClient(sub string) policy.AssignmentsClient {
+
+	c := policy.NewAssignmentsClient(sub)
+	a, err := auth.NewAuthorizerFromEnvironment()
+	if err == nil {
+		c.Authorizer = a
+	} else {
+		log.Printf("[ERROR] Unable to authorise Azure Policy Assignment client: %v", err)
+	}
+	return c
+}

--- a/service_packs/storage/account.go
+++ b/service_packs/storage/account.go
@@ -8,8 +8,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2019-04-01/storage"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
 	"github.com/Azure/go-autorest/autorest/to"
-
-	"github.com/citihub/probr/internal/azureutil"
+	"github.com/citihub/probr/service_packs/storage/azure"
 )
 
 // DeleteAccount - deletes a storage account given the azure contect, resource group and account name
@@ -57,7 +56,7 @@ func CreateWithNetworkRuleSet(ctx context.Context, accountName, accountGroupName
 			Sku: &storage.Sku{
 				Name: storage.StandardLRS},
 			Kind:                              storage.Storage,
-			Location:                          to.StringPtr(azureutil.ResourceLocation()),
+			Location:                          to.StringPtr(azure.ResourceLocation()),
 			AccountPropertiesCreateParameters: networkRuleSetParam,
 			Tags:                              tags,
 		})
@@ -95,10 +94,10 @@ func getAccountKeys(ctx context.Context, accountName, accountGroupName string) (
 func accountClient() storage.AccountsClient {
 
 	// Create an azure storage account client object via the connection config vars
-	c := storage.NewAccountsClient(azureutil.SubscriptionID())
+	c := storage.NewAccountsClient(azure.SubscriptionID())
 
 	// Create an authorization object via the connection config vars
-	authorizer := auth.NewClientCredentialsConfig(azureutil.ClientID(), azureutil.ClientSecret(), azureutil.TenantID())
+	authorizer := auth.NewClientCredentialsConfig(azure.ClientID(), azure.ClientSecret(), azure.TenantID())
 
 	authorizerToken, err := authorizer.Authorizer()
 	if err == nil {

--- a/service_packs/storage/account.go
+++ b/service_packs/storage/account.go
@@ -8,7 +8,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2019-04-01/storage"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
 	"github.com/Azure/go-autorest/autorest/to"
-	"github.com/citihub/probr/service_packs/storage/azure"
+	azureutil "github.com/citihub/probr/service_packs/storage/azure"
 )
 
 // DeleteAccount - deletes a storage account given the azure contect, resource group and account name
@@ -56,7 +56,7 @@ func CreateWithNetworkRuleSet(ctx context.Context, accountName, accountGroupName
 			Sku: &storage.Sku{
 				Name: storage.StandardLRS},
 			Kind:                              storage.Storage,
-			Location:                          to.StringPtr(azure.ResourceLocation()),
+			Location:                          to.StringPtr(azureutil.ResourceLocation()),
 			AccountPropertiesCreateParameters: networkRuleSetParam,
 			Tags:                              tags,
 		})
@@ -94,10 +94,10 @@ func getAccountKeys(ctx context.Context, accountName, accountGroupName string) (
 func accountClient() storage.AccountsClient {
 
 	// Create an azure storage account client object via the connection config vars
-	c := storage.NewAccountsClient(azure.SubscriptionID())
+	c := storage.NewAccountsClient(azureutil.SubscriptionID())
 
 	// Create an authorization object via the connection config vars
-	authorizer := auth.NewClientCredentialsConfig(azure.ClientID(), azure.ClientSecret(), azure.TenantID())
+	authorizer := auth.NewClientCredentialsConfig(azureutil.ClientID(), azureutil.ClientSecret(), azureutil.TenantID())
 
 	authorizerToken, err := authorizer.Authorizer()
 	if err == nil {

--- a/service_packs/storage/azure/access_whitelisting/access_whitelisting.go
+++ b/service_packs/storage/azure/access_whitelisting/access_whitelisting.go
@@ -13,13 +13,13 @@ import (
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/cucumber/godog"
 
-	"github.com/citihub/probr/internal/azureutil"
-	"github.com/citihub/probr/internal/azureutil/group"
-	"github.com/citihub/probr/internal/azureutil/policy"
 	"github.com/citihub/probr/internal/summary"
 	"github.com/citihub/probr/internal/utils"
 	"github.com/citihub/probr/service_packs/coreengine"
 	"github.com/citihub/probr/service_packs/storage"
+	azureutil "github.com/citihub/probr/service_packs/storage/azure"
+	"github.com/citihub/probr/service_packs/storage/azure/group"
+	"github.com/citihub/probr/service_packs/storage/azure/policy"
 )
 
 const (

--- a/service_packs/storage/azure/azurebase.go
+++ b/service_packs/storage/azure/azurebase.go
@@ -1,4 +1,4 @@
-package azure
+package azureutil
 
 import (
 	"log"

--- a/service_packs/storage/azure/azurebase.go
+++ b/service_packs/storage/azure/azurebase.go
@@ -1,4 +1,4 @@
-package azureutil
+package azure
 
 import (
 	"log"

--- a/service_packs/storage/azure/encryption_in_flight/encryption_in_flight.go
+++ b/service_packs/storage/azure/encryption_in_flight/encryption_in_flight.go
@@ -12,12 +12,12 @@ import (
 	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/cucumber/godog"
 
-	"github.com/citihub/probr/internal/azureutil"
-	"github.com/citihub/probr/internal/azureutil/group"
 	"github.com/citihub/probr/internal/summary"
 	"github.com/citihub/probr/internal/utils"
 	"github.com/citihub/probr/service_packs/coreengine"
 	"github.com/citihub/probr/service_packs/storage"
+	azureutil "github.com/citihub/probr/service_packs/storage/azure"
+	"github.com/citihub/probr/service_packs/storage/azure/group"
 )
 
 type scenarioState struct {

--- a/service_packs/storage/azure/group/group.go
+++ b/service_packs/storage/azure/group/group.go
@@ -7,18 +7,17 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-02-01/resources"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
 	"github.com/Azure/go-autorest/autorest/to"
-
-	"github.com/citihub/probr/internal/azureutil"
+	"github.com/citihub/probr/service_packs/storage/azure"
 )
 
 // Create creates a new Resource Group in the default location (configured using the AZURE_LOCATION environment variable).
 func Create(ctx context.Context, name string) (resources.Group, error) {
-	log.Printf("[INFO] creating Resource Group '%s' in location: %v", name, azureutil.ResourceLocation())
+	log.Printf("[INFO] creating Resource Group '%s' in location: %v", name, azure.ResourceLocation())
 	return client().CreateOrUpdate(
 		ctx,
 		name,
 		resources.Group{
-			Location: to.StringPtr(azureutil.ResourceLocation()),
+			Location: to.StringPtr(azure.ResourceLocation()),
 		})
 }
 
@@ -30,12 +29,12 @@ func Get(ctx context.Context, name string) (resources.Group, error) {
 
 // CreateWithTags creates a new Resource Group in the default location (configured using the AZURE_LOCATION environment variable) and sets the supplied tags.
 func CreateWithTags(ctx context.Context, name string, tags map[string]*string) (resources.Group, error) {
-	log.Printf("[INFO] creating Resource Group '%s' on location: '%v'", name, azureutil.ResourceLocation())
+	log.Printf("[INFO] creating Resource Group '%s' on location: '%v'", name, azure.ResourceLocation())
 	return client().CreateOrUpdate(
 		ctx,
 		name,
 		resources.Group{
-			Location: to.StringPtr(azureutil.ResourceLocation()),
+			Location: to.StringPtr(azure.ResourceLocation()),
 			Tags:     tags,
 		})
 }
@@ -43,10 +42,10 @@ func CreateWithTags(ctx context.Context, name string, tags map[string]*string) (
 func client() resources.GroupsClient {
 
 	// Create an azure resource group client object via the connection config vars
-	c := resources.NewGroupsClient(azureutil.SubscriptionID())
+	c := resources.NewGroupsClient(azure.SubscriptionID())
 
 	// Create an authorization object via the connection config vars
-	authorizer := auth.NewClientCredentialsConfig(azureutil.ClientID(), azureutil.ClientSecret(), azureutil.TenantID())
+	authorizer := auth.NewClientCredentialsConfig(azure.ClientID(), azure.ClientSecret(), azure.TenantID())
 
 	authorizerToken, err := authorizer.Authorizer()
 	if err == nil {

--- a/service_packs/storage/azure/group/group.go
+++ b/service_packs/storage/azure/group/group.go
@@ -7,17 +7,17 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-02-01/resources"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
 	"github.com/Azure/go-autorest/autorest/to"
-	"github.com/citihub/probr/service_packs/storage/azure"
+	azureutil "github.com/citihub/probr/service_packs/storage/azure"
 )
 
 // Create creates a new Resource Group in the default location (configured using the AZURE_LOCATION environment variable).
 func Create(ctx context.Context, name string) (resources.Group, error) {
-	log.Printf("[INFO] creating Resource Group '%s' in location: %v", name, azure.ResourceLocation())
+	log.Printf("[INFO] creating Resource Group '%s' in location: %v", name, azureutil.ResourceLocation())
 	return client().CreateOrUpdate(
 		ctx,
 		name,
 		resources.Group{
-			Location: to.StringPtr(azure.ResourceLocation()),
+			Location: to.StringPtr(azureutil.ResourceLocation()),
 		})
 }
 
@@ -29,12 +29,12 @@ func Get(ctx context.Context, name string) (resources.Group, error) {
 
 // CreateWithTags creates a new Resource Group in the default location (configured using the AZURE_LOCATION environment variable) and sets the supplied tags.
 func CreateWithTags(ctx context.Context, name string, tags map[string]*string) (resources.Group, error) {
-	log.Printf("[INFO] creating Resource Group '%s' on location: '%v'", name, azure.ResourceLocation())
+	log.Printf("[INFO] creating Resource Group '%s' on location: '%v'", name, azureutil.ResourceLocation())
 	return client().CreateOrUpdate(
 		ctx,
 		name,
 		resources.Group{
-			Location: to.StringPtr(azure.ResourceLocation()),
+			Location: to.StringPtr(azureutil.ResourceLocation()),
 			Tags:     tags,
 		})
 }
@@ -42,10 +42,10 @@ func CreateWithTags(ctx context.Context, name string, tags map[string]*string) (
 func client() resources.GroupsClient {
 
 	// Create an azure resource group client object via the connection config vars
-	c := resources.NewGroupsClient(azure.SubscriptionID())
+	c := resources.NewGroupsClient(azureutil.SubscriptionID())
 
 	// Create an authorization object via the connection config vars
-	authorizer := auth.NewClientCredentialsConfig(azure.ClientID(), azure.ClientSecret(), azure.TenantID())
+	authorizer := auth.NewClientCredentialsConfig(azureutil.ClientID(), azureutil.ClientSecret(), azureutil.TenantID())
 
 	authorizerToken, err := authorizer.Authorizer()
 	if err == nil {

--- a/service_packs/storage/azure/policy/assignment.go
+++ b/service_packs/storage/azure/policy/assignment.go
@@ -6,8 +6,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-01-01/policy"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
-
-	"github.com/citihub/probr/internal/azureutil"
+	azureutil "github.com/citihub/probr/service_packs/storage/azure"
 )
 
 // AssignmentBySubscription gets a Policy Assignment by Policy Assignment name, scoped to a Subscription.

--- a/service_packs/storage/azure/policy/definition.go
+++ b/service_packs/storage/azure/policy/definition.go
@@ -6,8 +6,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-01-01/policy"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
-
-	"github.com/citihub/probr/internal/azureutil"
+	azureutil "github.com/citihub/probr/service_packs/storage/azure"
 )
 
 // DefinitionByName get a Policy Definition by name.


### PR DESCRIPTION
Part of Issue #218

All core logic used within a service pack needs to be moved outside of `internal/` to avoid complications when developing service packs in segmented directories. Other changes similar to this will follow.

Without this change, errors such as this will occur:
```
..\..\go\bin\pkg\mod\github.com\citihub\probr-k8s-service@v0.0.2\pack\pack.go:10:2: use of internal package github.com/citihub/probr/internal/coreengine not allowed
```