### PR TITLE
Updating pod specs, adding capability drop for NET_RAW policy

### DIFF
--- a/service_packs/kubernetes/assets/iam-azi-test-aib-curl.yaml
+++ b/service_packs/kubernetes/assets/iam-azi-test-aib-curl.yaml
@@ -18,5 +18,7 @@ spec:
     command: [ "sh", "-c", "sleep 1h" ]
     securityContext:
       allowPrivilegeEscalation: false
+      capabilities:
+        drop: ["NET_RAW"]
   nodeSelector:
     kubernetes.io/os: linux

--- a/service_packs/kubernetes/assets/psp-azp-hostport-approved.yaml
+++ b/service_packs/kubernetes/assets/psp-azp-hostport-approved.yaml
@@ -22,3 +22,5 @@ spec:
       mountPath: /data/demo
     securityContext:
       allowPrivilegeEscalation: false
+      capabilities:
+        drop: ["NET_RAW"]

--- a/service_packs/kubernetes/assets/psp-azp-hostport-unapproved.yaml
+++ b/service_packs/kubernetes/assets/psp-azp-hostport-unapproved.yaml
@@ -24,4 +24,6 @@ spec:
     - name: sec-ctx-vol
       mountPath: /data/demo
     securityContext:
-      allowPrivilegeEscalation: false            
+      allowPrivilegeEscalation: false  
+      capabilities:
+        drop: ["NET_RAW"]          

--- a/service_packs/kubernetes/assets/psp-azp-privileges.yaml
+++ b/service_packs/kubernetes/assets/psp-azp-privileges.yaml
@@ -23,3 +23,5 @@ spec:
       periodSeconds: 5
     securityContext:
       allowPrivilegeEscalation: {{ allowPrivilegeEscalation }}
+      capabilities:
+        drop: ["NET_RAW"]

--- a/service_packs/kubernetes/assets/psp-azp-seccomp-approved.yaml
+++ b/service_packs/kubernetes/assets/psp-azp-seccomp-approved.yaml
@@ -22,4 +22,6 @@ spec:
       initialDelaySeconds: 5
       periodSeconds: 5
     securityContext:
-      allowPrivilegeEscalation: false             
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: ["NET_RAW"]

--- a/service_packs/kubernetes/assets/psp-azp-seccomp-unapproved.yaml
+++ b/service_packs/kubernetes/assets/psp-azp-seccomp-unapproved.yaml
@@ -15,4 +15,6 @@ spec:
     image: {{ probr-compatible-image }}
     command: [ "sh", "-c", "sleep 1h" ]
     securityContext:
-      allowPrivilegeEscalation: false            
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: ["NET_RAW"]

--- a/service_packs/kubernetes/assets/psp-azp-seccomp-undefined.yaml
+++ b/service_packs/kubernetes/assets/psp-azp-seccomp-undefined.yaml
@@ -15,4 +15,6 @@ spec:
     image: {{ probr-compatible-image }}
     command: [ "sh", "-c", "sleep 1h" ]
     securityContext:
-      allowPrivilegeEscalation: false            
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: ["NET_RAW"]

--- a/service_packs/kubernetes/assets/psp-azp-volumetypes-approved.yaml
+++ b/service_packs/kubernetes/assets/psp-azp-volumetypes-approved.yaml
@@ -21,6 +21,7 @@ spec:
     volumeMounts:
     - name: approved-volume
       mountPath: /tmp/test
-      
     securityContext:
       allowPrivilegeEscalation: false
+      capabilities:
+        drop: ["NET_RAW"]

--- a/service_packs/kubernetes/assets/psp-azp-volumetypes-unapproved.yaml
+++ b/service_packs/kubernetes/assets/psp-azp-volumetypes-unapproved.yaml
@@ -21,6 +21,7 @@ spec:
     volumeMounts:
     - name: unapproved-volume
       mountPath: /data/demo
-      
     securityContext:
-      allowPrivilegeEscalation: false            
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: ["NET_RAW"]


### PR DESCRIPTION
Updating pod specs, adding capability drop for NET_RAW policy. Hardcoded for now, will change to configurable in next PR

Relates to #95 