### PR TITLE
Adding configurable drop capabilities to GetPodFromObj

### DIFF
--- a/config/defaults.go
+++ b/config/defaults.go
@@ -23,7 +23,7 @@ func setFromEnvOrDefaults(e *ConfigVars) {
 	e.set(&e.ServicePacks.Kubernetes.AuthorisedContainerRegistry, "PROBR_AUTHORISED_REGISTRY", "")
 	e.set(&e.ServicePacks.Kubernetes.UnauthorisedContainerRegistry, "PROBR_UNAUTHORISED_REGISTRY", "")
 	e.set(&e.ServicePacks.Kubernetes.ProbeImage, "PROBR_PROBE_IMAGE", "citihub/probr-probe")
-	e.set(&e.ServicePacks.Kubernetes.ContainerDropCapabilities, "PROBR_CONTAINER_DROP_CAPABILITIES", "[\"NET_RAW\"]")
+	e.set(&e.ServicePacks.Kubernetes.ContainerDropCapabilities, "PROBR_CONTAINER_DROP_CAPABILITIES", []string{"NET_RAW"})
 
 	e.set(&e.CloudProviders.Azure.TenantID, "AZURE_TENANT_ID", "")
 	e.set(&e.CloudProviders.Azure.SubscriptionID, "AZURE_SUBSCRIPTION_ID", "")

--- a/config/types.go
+++ b/config/types.go
@@ -37,7 +37,7 @@ type Kubernetes struct {
 	AuthorisedContainerRegistry   string   `yaml:"AuthorisedContainerRegistry"`
 	UnauthorisedContainerRegistry string   `yaml:"UnauthorisedContainerRegistry"`
 	ProbeImage                    string   `yaml:"ProbeImage"`
-	ContainerDropCapabilities     string   `yaml:"ContainerDropCapabilities"`
+	ContainerDropCapabilities     []string `yaml:"ContainerDropCapabilities"`
 }
 
 type Storage struct {

--- a/service_packs/kubernetes/assets/iam-azi-test-aib-curl.yaml
+++ b/service_packs/kubernetes/assets/iam-azi-test-aib-curl.yaml
@@ -19,6 +19,6 @@ spec:
     securityContext:
       allowPrivilegeEscalation: false
       capabilities:
-        drop: {{ probr-cap-drop }}
+        drop: [ {{ probr-cap-drop }} ]
   nodeSelector:
     kubernetes.io/os: linux

--- a/service_packs/kubernetes/assets/psp-azp-hostport-approved.yaml
+++ b/service_packs/kubernetes/assets/psp-azp-hostport-approved.yaml
@@ -26,4 +26,4 @@ spec:
     securityContext:
       allowPrivilegeEscalation: false
       capabilities:
-        drop: {{ probr-cap-drop }}
+        drop: [ {{ probr-cap-drop }} ]

--- a/service_packs/kubernetes/assets/psp-azp-hostport-unapproved.yaml
+++ b/service_packs/kubernetes/assets/psp-azp-hostport-unapproved.yaml
@@ -29,4 +29,4 @@ spec:
     securityContext:
       allowPrivilegeEscalation: false  
       capabilities:
-        drop: {{ probr-cap-drop }}          
+        drop: [ {{ probr-cap-drop }} ]

--- a/service_packs/kubernetes/assets/psp-azp-privileges.yaml
+++ b/service_packs/kubernetes/assets/psp-azp-privileges.yaml
@@ -27,4 +27,4 @@ spec:
     securityContext:
       allowPrivilegeEscalation: {{ allowPrivilegeEscalation }}
       capabilities:
-        drop: {{ probr-cap-drop }}
+        drop: [ {{ probr-cap-drop }} ]

--- a/service_packs/kubernetes/assets/psp-azp-seccomp-approved.yaml
+++ b/service_packs/kubernetes/assets/psp-azp-seccomp-approved.yaml
@@ -27,4 +27,4 @@ spec:
     securityContext:
       allowPrivilegeEscalation: false
       capabilities:
-        drop: {{ probr-cap-drop }}
+        drop: [ {{ probr-cap-drop }} ]

--- a/service_packs/kubernetes/assets/psp-azp-seccomp-unapproved.yaml
+++ b/service_packs/kubernetes/assets/psp-azp-seccomp-unapproved.yaml
@@ -20,4 +20,4 @@ spec:
     securityContext:
       allowPrivilegeEscalation: false
       capabilities:
-        drop: {{ probr-cap-drop }}
+        drop: [ {{ probr-cap-drop }} ]

--- a/service_packs/kubernetes/assets/psp-azp-seccomp-undefined.yaml
+++ b/service_packs/kubernetes/assets/psp-azp-seccomp-undefined.yaml
@@ -20,4 +20,4 @@ spec:
     securityContext:
       allowPrivilegeEscalation: false
       capabilities:
-        drop: {{ probr-cap-drop }}
+        drop: [ {{ probr-cap-drop }} ]

--- a/service_packs/kubernetes/assets/psp-azp-volumetypes-approved.yaml
+++ b/service_packs/kubernetes/assets/psp-azp-volumetypes-approved.yaml
@@ -27,4 +27,4 @@ spec:
     securityContext:
       allowPrivilegeEscalation: false
       capabilities:
-        drop: {{ probr-cap-drop }}
+        drop: [ {{ probr-cap-drop }} ]

--- a/service_packs/kubernetes/assets/psp-azp-volumetypes-unapproved.yaml
+++ b/service_packs/kubernetes/assets/psp-azp-volumetypes-unapproved.yaml
@@ -27,4 +27,4 @@ spec:
     securityContext:
       allowPrivilegeEscalation: false
       capabilities:
-        drop: {{ probr-cap-drop }}
+        drop: [ {{ probr-cap-drop }} ]

--- a/service_packs/kubernetes/kube.go
+++ b/service_packs/kubernetes/kube.go
@@ -196,7 +196,8 @@ func (k *Kube) CreatePod(podName string, ns string, containerName string, image 
 func (k *Kube) CreatePodFromYaml(y []byte, pname string, ns string, image string, aadpodidbinding string, w bool, probe *audit.Probe) (*apiv1.Pod, error) {
 	vars := config.Vars.ServicePacks.Kubernetes
 	approvedImage := vars.AuthorisedContainerRegistry + "/" + vars.ProbeImage
-	replaceSpecValues := strings.NewReplacer("{{ probr-compatible-image }}", approvedImage, "{{ probr-caller-function }}", utils.CallerName(2), "{{ probr-cap-drop }}", vars.ContainerDropCapabilities)
+	containerDropCapabilities := strings.Join(vars.ContainerDropCapabilities, ",")
+	replaceSpecValues := strings.NewReplacer("{{ probr-compatible-image }}", approvedImage, "{{ probr-caller-function }}", utils.CallerName(2), "{{ probr-cap-drop }}", containerDropCapabilities)
 	podSpec := utils.ReplaceBytesMultipleValues(y, replaceSpecValues)
 
 	o, _, err := scheme.Codecs.UniversalDeserializer().Decode(podSpec, nil, nil)

--- a/service_packs/kubernetes/pod_handlers.go
+++ b/service_packs/kubernetes/pod_handlers.go
@@ -9,6 +9,7 @@ import (
 	"math/rand"
 	"time"
 
+	"github.com/citihub/probr/config"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -121,8 +122,9 @@ func defaultPodSecurityContext() *apiv1.PodSecurityContext {
 
 func defaultContainerSecurityContext() *apiv1.SecurityContext {
 	b := false
+
 	capabilities := apiv1.Capabilities{
-		Drop: []apiv1.Capability{"NET_RAW"},
+		Drop: GetContainerDropCapabilitiesFromConfig(),
 	}
 
 	return &apiv1.SecurityContext{
@@ -164,4 +166,18 @@ func waitForDelete(c *k8s.Clientset, ns string, n string) error {
 	log.Printf("[INFO] *** Completed waiting for DELETE on pod %v", n)
 
 	return nil
+}
+
+func GetContainerDropCapabilitiesFromConfig() []apiv1.Capability {
+	var apiDropCapabilities []apiv1.Capability
+
+	// Adding all values from config
+	dropCapabilitiesFromConfig := config.Vars.ServicePacks.Kubernetes.ContainerDropCapabilities
+	for _, dropCap := range dropCapabilitiesFromConfig {
+		if dropCap != "" {
+			apiDropCapabilities = append(apiDropCapabilities, apiv1.Capability(dropCap))
+		}
+	}
+
+	return apiDropCapabilities
 }

--- a/service_packs/kubernetes/pod_handlers_test.go
+++ b/service_packs/kubernetes/pod_handlers_test.go
@@ -1,0 +1,66 @@
+package kubernetes
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/citihub/probr/config"
+	apiv1 "k8s.io/api/core/v1"
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
+)
+
+func TestGetDropCapabilitiesFromConfig(t *testing.T) {
+
+	// Default config
+	dropCapabilitiesFromDefaultValue := []apiv1.Capability{"NET_RAW"} //This test will fail if default value changes for config.Vars.ServicePacks.Kubernetes.ContainerDropCapabilities. Adjust as needed.
+
+	// Custom config - single value
+	customConfig := []string{"CAP_SETUID"}
+	dropCapabilitiesFromCustomConfig := []apiv1.Capability{"CAP_SETUID"}
+
+	// Custom config - list
+	customConfigList := []string{"NET_RAW", "CAP_SETUID", "CAP_SYS_ADMIN"}
+	dropCapabilitiesFromCustomConfigList := []apiv1.Capability{"NET_RAW", "CAP_SETUID", "CAP_SYS_ADMIN"}
+
+	tests := []struct {
+		testName           string
+		customConfigValues []string
+		expectedResult     []apiv1.Capability
+	}{
+		{
+			testName:           "ShouldReturn_UsingDefaultValue",
+			customConfigValues: nil, //Use default
+			expectedResult:     dropCapabilitiesFromDefaultValue,
+		},
+		{
+			testName:           "ShouldReturn_UsingCustomConfig_SingleValue",
+			customConfigValues: customConfig,
+			expectedResult:     dropCapabilitiesFromCustomConfig,
+		},
+		{
+			testName:           "ShouldReturn_UsingCustomConfig_List",
+			customConfigValues: customConfigList,
+			expectedResult:     dropCapabilitiesFromCustomConfigList,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			if tt.customConfigValues == nil {
+				// Create default config
+				err := config.Init("")
+				if err != nil {
+					t.Errorf("[ERROR] error returned from config.Init: %v", err)
+				}
+			} else {
+				// Set custom config vars
+				// Only ContainerDropCapabilities for now. Extend if more config vars are used.
+				config.Vars.ServicePacks.Kubernetes.ContainerDropCapabilities = tt.customConfigValues
+			}
+
+			if got := GetContainerDropCapabilitiesFromConfig(); !reflect.DeepEqual(got, tt.expectedResult) {
+				t.Errorf("defaultContainerSecurityContext() = %v, Expected result: %v", got, tt.expectedResult)
+			}
+		})
+	}
+}

--- a/service_packs/kubernetes/pod_security_policy/helpers.go
+++ b/service_packs/kubernetes/pod_security_policy/helpers.go
@@ -553,11 +553,6 @@ func (psp *PSP) CreatePODSettingCapabilities(c *[]string, probe *audit.Probe) (*
 				}
 				con.SecurityContext.Capabilities.Add =
 					append(con.SecurityContext.Capabilities.Add, apiv1.Capability(cap))
-				//con.SecurityContext.Capabilities.Drop = append(con.SecurityContext.Capabilities.Drop, apiv1.Capability("NET_RAW"))
-				// TODO: Remove above line, since it will cause the values for container drop capabilities to be duplicated
-				// Keeping commented out for now to ensure no edge cases will appear.
-				// Tested runnig probr --tags=@k-psp and got 33/36 succeeded scenarios
-				// Theory is that this line is not needed, since GetPodObject will call defaultContainerSecurityContext, which gets the drop capability from config.
 			}
 		}
 	}

--- a/service_packs/kubernetes/pod_security_policy/helpers.go
+++ b/service_packs/kubernetes/pod_security_policy/helpers.go
@@ -488,7 +488,7 @@ func (psp *PSP) CreatePODSettingSecurityContext(pr *bool, pe *bool, runAsUser *i
 		runAsUser = &i
 	}
 	capabilities := apiv1.Capabilities{
-		Drop: []apiv1.Capability{"NET_RAW"},
+		Drop: kubernetes.GetContainerDropCapabilitiesFromConfig(),
 	}
 
 	sc := apiv1.SecurityContext{
@@ -553,7 +553,11 @@ func (psp *PSP) CreatePODSettingCapabilities(c *[]string, probe *audit.Probe) (*
 				}
 				con.SecurityContext.Capabilities.Add =
 					append(con.SecurityContext.Capabilities.Add, apiv1.Capability(cap))
-				con.SecurityContext.Capabilities.Drop = append(con.SecurityContext.Capabilities.Drop, apiv1.Capability("NET_RAW"))
+				//con.SecurityContext.Capabilities.Drop = append(con.SecurityContext.Capabilities.Drop, apiv1.Capability("NET_RAW"))
+				// TODO: Remove above line, since it will cause the values for container drop capabilities to be duplicated
+				// Keeping commented out for now to ensure no edge cases will appear.
+				// Tested runnig probr --tags=@k-psp and got 33/36 succeeded scenarios
+				// Theory is that this line is not needed, since GetPodObject will call defaultContainerSecurityContext, which gets the drop capability from config.
 			}
 		}
 	}


### PR DESCRIPTION
- Adding configurable drop capabilities to GetPodFromObj
  - defaultContainerSecurityContext
  - CreatePODSettingSecurityContext
- Switching config value to list. Refactored previous method

Regression test for PSP:
![image](https://user-images.githubusercontent.com/62344673/107705535-ddf56400-6c8c-11eb-93d5-1b7ab8f361ef.png)

Closes #95 