### PR TITLE
Fixes hostPort probe

### DIFF
--- a/config/defaults.go
+++ b/config/defaults.go
@@ -17,6 +17,7 @@ func setFromEnvOrDefaults(e *ConfigVars) {
 	e.set(&e.LogLevel, "PROBR_LOG_LEVEL", "ERROR")
 	e.set(&e.OverwriteHistoricalAudits, "OVERWRITE_AUDITS", "true")
 
+	e.set(&e.ServicePacks.Kubernetes.KeepPods, "PROBR_KEEP_PODS", "false")
 	e.set(&e.ServicePacks.Kubernetes.KubeConfigPath, "KUBE_CONFIG", getDefaultKubeConfigPath())
 	e.set(&e.ServicePacks.Kubernetes.KubeContext, "KUBE_CONTEXT", "")
 	e.set(&e.ServicePacks.Kubernetes.SystemClusterRoles, "", []string{"system:", "aks", "cluster-admin", "policy-agent"})
@@ -24,6 +25,7 @@ func setFromEnvOrDefaults(e *ConfigVars) {
 	e.set(&e.ServicePacks.Kubernetes.UnauthorisedContainerRegistry, "PROBR_UNAUTHORISED_REGISTRY", "")
 	e.set(&e.ServicePacks.Kubernetes.ProbeImage, "PROBR_PROBE_IMAGE", "citihub/probr-probe")
 	e.set(&e.ServicePacks.Kubernetes.ContainerDropCapabilities, "PROBR_CONTAINER_DROP_CAPABILITIES", []string{"NET_RAW"})
+	e.set(&e.ServicePacks.Kubernetes.UnapprovedHostPort, "PROBR_UNAPPROVED_HOSTPORT", "22")
 
 	e.set(&e.CloudProviders.Azure.TenantID, "AZURE_TENANT_ID", "")
 	e.set(&e.CloudProviders.Azure.SubscriptionID, "AZURE_SUBSCRIPTION_ID", "")

--- a/config/types.go
+++ b/config/types.go
@@ -30,6 +30,7 @@ type ServicePacks struct {
 
 type Kubernetes struct {
 	exclusionLogged               bool
+	KeepPods                      string   `yaml:"KeepPods"`
 	Probes                        []Probe  `yaml:"Probes"`
 	KubeConfigPath                string   `yaml:"KubeConfig"`
 	KubeContext                   string   `yaml:"KubeContext"`
@@ -38,6 +39,7 @@ type Kubernetes struct {
 	UnauthorisedContainerRegistry string   `yaml:"UnauthorisedContainerRegistry"`
 	ProbeImage                    string   `yaml:"ProbeImage"`
 	ContainerDropCapabilities     []string `yaml:"ContainerDropCapabilities"`
+	UnapprovedHostPort            string   `yaml:"UnapprovedHostPort"`
 }
 
 type Storage struct {

--- a/service_packs/kubernetes/assets/psp-azp-hostport-notdefined.yaml
+++ b/service_packs/kubernetes/assets/psp-azp-hostport-notdefined.yaml
@@ -2,17 +2,17 @@ apiVersion: v1
 kind: Pod
 metadata:
   #name: security-context-demo
-  labels: 
+  labels:
     caller: {{ probr-caller-function }}
     feature: k-psp-012
   annotations:
     seccomp.security.alpha.kubernetes.io/pod: "runtime/default"
-spec:  
+spec:
   securityContext:
-    runAsUser: 1000    
+    runAsUser: 1000
     runAsGroup: 3000
     fsGroup: 2000
-    supplementalGroups: [ 1 ]    
+    supplementalGroups: [ 1 ]
   volumes:
   - name: sec-ctx-vol
     emptyDir: {}

--- a/service_packs/kubernetes/assets/psp-azp-hostport-unapproved.yaml
+++ b/service_packs/kubernetes/assets/psp-azp-hostport-unapproved.yaml
@@ -2,31 +2,31 @@ apiVersion: v1
 kind: Pod
 metadata:
   #name: security-context-demo
-  labels: 
+  labels:
     caller: {{ probr-caller-function }}
     feature: k-psp-012
   annotations:
     seccomp.security.alpha.kubernetes.io/pod: "runtime/default"
-spec:  
+spec:
   securityContext:
-    runAsUser: 1000    
+    runAsUser: 1000
     runAsGroup: 3000
     fsGroup: 2000
-    supplementalGroups: [ 1 ]    
+    supplementalGroups: [ 1 ]
   volumes:
   - name: sec-ctx-vol
     emptyDir: {}
   containers:
   - name: psp-azp-hostport-unapproved
     image: {{ probr-compatible-image }}
-    command: [ "sh", "-c", "sleep 1h" ]    
+    command: [ "sh", "-c", "sleep 1h" ]
     ports:
-    - containerPort: 8086
-      hostPort: 8086
+    - containerPort: {{ unapproved-port }}
+      hostPort: {{ unapproved-port }}
     volumeMounts:
     - name: sec-ctx-vol
       mountPath: /data/demo
     securityContext:
-      allowPrivilegeEscalation: false  
+      allowPrivilegeEscalation: false
       capabilities:
         drop: [ {{ probr-cap-drop }} ]

--- a/service_packs/kubernetes/pod_handlers.go
+++ b/service_packs/kubernetes/pod_handlers.go
@@ -181,3 +181,7 @@ func GetContainerDropCapabilitiesFromConfig() []apiv1.Capability {
 
 	return apiDropCapabilities
 }
+
+func GetUnapprovedHostPortFromConfig() string {
+	return config.Vars.ServicePacks.Kubernetes.UnapprovedHostPort
+}

--- a/service_packs/kubernetes/pod_security_policy/pod_security_policy.feature
+++ b/service_packs/kubernetes/pod_security_policy/pod_security_policy.feature
@@ -189,17 +189,14 @@ So that a policy of least privilege can be enforced in order to prevent maliciou
             | undefined  | Fail      | Approved seccomp profile required           |
 
     @k-psp-012
-	Scenario Outline: Prevent deployments from accessing unapproved port range
-		Given a Kubernetes cluster exists which we can deploy into
-		And some system exists to prevent Kubernetes deployments with unapproved port range from being deployed to an existing Kubernetes cluster
+    Scenario Outline: Prevent pods from exposing unapproved host ports
+    		Given a Kubernetes cluster exists which we can deploy into
+    		And some system exists to prevent Kubernetes deployments with unapproved port range from being deployed to an existing Kubernetes cluster
         When a Kubernetes deployment is applied to an existing Kubernetes cluster
-		And an "<requested>" port range is requested for the Kubernetes deployment
-		Then the operation will "<RESULT>" with an error "<ERRORMESSAGE>"
-		But I should not be able to perform a command that access an unapproved port range
-		And I should be able to perform an allowed command
+    		And an "<requested>" hostPort is requested for the Kubernetes deployment
+    		Then the operation will "<RESULT>" with an error "<ERRORMESSAGE>"
 
-		Examples:
-			| requested 	| RESULT 	| ERRORMESSAGE							|
-			| unapproved  	| Fail  	| Cannot access unapproved port range	|
-			| approved		| Succeed	|									  	|
-			| not defined	| Succeed	|	                                    |
+    		Examples:
+    			| requested 	| RESULT 	| ERRORMESSAGE							          |
+    			| unapproved  | Fail  	| Cannot access unapproved port range	|
+    			| not defined	| Succeed	|	                                    |

--- a/service_packs/kubernetes/pod_security_policy/pod_security_policy.go
+++ b/service_packs/kubernetes/pod_security_policy/pod_security_policy.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"path/filepath"
-	"strconv"
 	"strings"
 
 	"github.com/cucumber/godog"
@@ -12,11 +11,6 @@ import (
 	"github.com/citihub/probr/service_packs/coreengine"
 	"github.com/citihub/probr/service_packs/kubernetes"
 	"github.com/citihub/probr/utils"
-)
-
-const (
-	unapprovedPort = 8080
-	//TODO: make this configurable at runtime
 )
 
 type ProbeStruct struct{}
@@ -745,9 +739,10 @@ func (s *scenarioState) anPortRangeIsRequestedForTheKubernetesDeployment(portRan
 
 	switch portRange {
 	case "unapproved":
+		unapprovedHostPort := kubernetes.GetUnapprovedHostPortFromConfig()
 		y, err = utils.ReadStaticFile(kubernetes.AssetsDir, "psp-azp-hostport-unapproved.yaml")
-		yaml = utils.ReplaceBytesValue(y, "{{ unapproved-port }}", strconv.Itoa(unapprovedPort))
-		description = fmt.Sprintf("%s port range is requested for kubernetes deployment. Port was %v.", portRange, unapprovedPort)
+		yaml = utils.ReplaceBytesValue(y, "{{ unapproved-port }}", unapprovedHostPort)
+		description = fmt.Sprintf("%s port range is requested for kubernetes deployment. Port was %v.", portRange, unapprovedHostPort)
 	case "not defined":
 		yaml, err = utils.ReadStaticFile(kubernetes.AssetsDir, "psp-azp-hostport-notdefined.yaml")
 		description = fmt.Sprintf("%s port range is requested for kubernetes deployment.", portRange)
@@ -1022,10 +1017,9 @@ func (p ProbeStruct) ScenarioInitialize(ctx *godog.ScenarioContext) {
 	ctx.Step(`^I should be able to perform an allowed command$`, ps.performAllowedCommand)
 
 	ctx.AfterScenario(func(s *godog.Scenario, err error) {
-		psp.TeardownPodSecurityProbe(ps.podState.PodName, p.Name())
+		//psp.TeardownPodSecurityProbe(ps.podState.PodName, p.Name())
 		ps.podState.PodName = ""
 		ps.podState.CreationError = nil
 		coreengine.LogScenarioEnd(s)
 	})
-
 }


### PR DESCRIPTION
- Removed the `approved` case, because it is an edge case where hostPort would be allowed for all namespaces.  If we wanted to test this thoroughly we'd deploy containers requesting hostPort for every port from 0-65535.
- Removed the `execute a command` step because it's ineffectual.  Running a command inside the container to listen on a port binds it to localhost and it's the Kubernetes mechanics that maps that to the host network.