### PR TITLE
expose godog format via cli flag

### DIFF
--- a/cmd/cli_flags/flags.go
+++ b/cmd/cli_flags/flags.go
@@ -102,7 +102,7 @@ func resultsformatHandler(v interface{}) {
 		options := []string{"cucumber", "events", "junit", "pretty", "progress"}
 		_, found := utils.FindString(options, *v.(*string))
 		if !found {
-			log.Fatalf("[ERROR] Unknown loglevel specified: '%s'. Must be one of %v", *v.(*string), options)
+			log.Fatalf("[ERROR] Unknown resultsformat specified: '%s'. Must be one of %v", *v.(*string), options)
 		} else {
 			config.Vars.ResultsFormat = *v.(*string)
 			config.SetLogFilter(config.Vars.ResultsFormat, os.Stderr)

--- a/cmd/cli_flags/flags.go
+++ b/cmd/cli_flags/flags.go
@@ -29,6 +29,7 @@ func HandleFlags() {
 	stringFlag("kubeconfig", "kube config file", kubeConfigHandler)
 	stringFlag("writedirectory", "output directory", writeDirHandler)
 	stringFlag("tags", "feature tags to include or exclude", tagsHandler)
+	stringFlag("resultsformat", "set the bdd results format (default = cucumber)", resultsformatHandler)
 	boolFlag("silent", "disable visual runtime indicator, useful for CI tasks", silentHandler)
 	boolFlag("nosummary", "switch off summary output", nosummaryHandler)
 	flag.Parse()
@@ -92,6 +93,19 @@ func loglevelHandler(v interface{}) {
 		} else {
 			config.Vars.LogLevel = *v.(*string)
 			config.SetLogFilter(config.Vars.LogLevel, os.Stderr)
+		}
+	}
+}
+
+func resultsformatHandler(v interface{}) {
+	if len(*v.(*string)) > 0 {
+		options := []string{"cucumber", "events", "junit", "pretty", "progress"}
+		_, found := utils.FindString(options, *v.(*string))
+		if !found {
+			log.Fatalf("[ERROR] Unknown loglevel specified: '%s'. Must be one of %v", *v.(*string), options)
+		} else {
+			config.Vars.ResultsFormat = *v.(*string)
+			config.SetLogFilter(config.Vars.ResultsFormat, os.Stderr)
 		}
 	}
 }

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -16,6 +16,7 @@ func setFromEnvOrDefaults(e *ConfigVars) {
 	e.set(&e.WriteDirectory, "PROBR_WRITE_DIRECTORY", "probr_output")
 	e.set(&e.LogLevel, "PROBR_LOG_LEVEL", "ERROR")
 	e.set(&e.OverwriteHistoricalAudits, "OVERWRITE_AUDITS", "true")
+	e.set(&e.ResultsFormat, "PROBR_RESULTS_FORMAT", "cucumber")
 
 	e.set(&e.ServicePacks.Kubernetes.KeepPods, "PROBR_KEEP_PODS", "false")
 	e.set(&e.ServicePacks.Kubernetes.KubeConfigPath, "KUBE_CONFIG", getDefaultKubeConfigPath())
@@ -25,7 +26,6 @@ func setFromEnvOrDefaults(e *ConfigVars) {
 	e.set(&e.ServicePacks.Kubernetes.UnauthorisedContainerRegistry, "PROBR_UNAUTHORISED_REGISTRY", "")
 	e.set(&e.ServicePacks.Kubernetes.ProbeImage, "PROBR_PROBE_IMAGE", "citihub/probr-probe")
 	e.set(&e.ServicePacks.Kubernetes.ContainerRequiredDropCapabilities, "PROBR_REQUIRED_DROP_CAPABILITIES", []string{"NET_RAW"})
-	//e.set(&e.ServicePacks.Kubernetes.ContainerAllowedAddCapabilities, "PROBR_ALLOWED_ADD_CAPABILITIES", []string{"CHOWN", "DAC_OVERRIDE", "FSETID", "FOWNER", "MKNOD", "NET_RAW", "SETGID", "SETUID", "SETFCAP", "SETPCAP", "NET_BIND_SERVICE", "SYS_CHROOT", "KILL", "AUDIT_WRITE"})
 	e.set(&e.ServicePacks.Kubernetes.ContainerAllowedAddCapabilities, "PROBR_ALLOWED_ADD_CAPABILITIES", []string{""})
 	e.set(&e.ServicePacks.Kubernetes.ApprovedVolumeTypes, "PROBR_APPROVED_VOLUME_TYPES", []string{"configmap", "emptydir", "persistentvolumeclaim"})
 	e.set(&e.ServicePacks.Kubernetes.UnapprovedHostPort, "PROBR_UNAPPROVED_HOSTPORT", "22")

--- a/config/types.go
+++ b/config/types.go
@@ -16,6 +16,7 @@ type ConfigVars struct {
 	NoSummary                 bool           // set by flags only
 	Silent                    bool           // set by flags only
 	Meta                      Meta           // set by CLI options only
+	ResultsFormat             string         // set by flags only
 }
 
 type Meta struct {

--- a/service_packs/coreengine/feature_probe_handler.go
+++ b/service_packs/coreengine/feature_probe_handler.go
@@ -58,7 +58,7 @@ func inMemGodogProbeHandler(gd *GodogProbe) (int, *bytes.Buffer, error) {
 func runTestSuite(o io.Writer, gd *GodogProbe) (int, error) {
 	tags := config.Vars.GetTags()
 	opts := godog.Options{
-		Format: "cucumber",
+		Format: config.Vars.ResultsFormat,
 		Output: colors.Colored(o),
 		Paths:  []string{gd.FeaturePath},
 		Tags:   tags,


### PR DESCRIPTION
Allows for the results format to be changed from the default `cucumber` format (e.g. junit)