### PR TITLE
Set probe concurrency to 2

### DIFF
--- a/service_packs/coreengine/feature_probe_handler.go
+++ b/service_packs/coreengine/feature_probe_handler.go
@@ -58,10 +58,11 @@ func inMemGodogProbeHandler(gd *GodogProbe) (int, *bytes.Buffer, error) {
 func runTestSuite(o io.Writer, gd *GodogProbe) (int, error) {
 	tags := config.Vars.GetTags()
 	opts := godog.Options{
-		Format: config.Vars.ResultsFormat,
-		Output: colors.Colored(o),
-		Paths:  []string{gd.FeaturePath},
-		Tags:   tags,
+		Concurrency: 2,
+		Format:      config.Vars.ResultsFormat,
+		Output:      colors.Colored(o),
+		Paths:       []string{gd.FeaturePath},
+		Tags:        tags,
 	}
 
 	status := godog.TestSuite{


### PR DESCRIPTION
This PR causes two probes to run simultaneously. Concurrent scenarios are not supported by Godog.

- Without concurrency Probr runs for 7-8 minutes
- With concurrency=2 Probr runs for 4-5 minutes
- With concurrency higher than 2 the runtime still appeared to be 4-5 minutes, and a "throttling" warning from the k8s api is printed to the CLI (ugly)