### PR TITLE
Revert probe concurrency to 1

### DIFF
--- a/service_packs/coreengine/feature_probe_handler.go
+++ b/service_packs/coreengine/feature_probe_handler.go
@@ -58,11 +58,10 @@ func inMemGodogProbeHandler(gd *GodogProbe) (int, *bytes.Buffer, error) {
 func runTestSuite(o io.Writer, gd *GodogProbe) (int, error) {
 	tags := config.Vars.GetTags()
 	opts := godog.Options{
-		Concurrency: 2,
-		Format:      config.Vars.ResultsFormat,
-		Output:      colors.Colored(o),
-		Paths:       []string{gd.FeaturePath},
-		Tags:        tags,
+		Format: config.Vars.ResultsFormat,
+		Output: colors.Colored(o),
+		Paths:  []string{gd.FeaturePath},
+		Tags:   tags,
 	}
 
 	status := godog.TestSuite{


### PR DESCRIPTION
Reverts citihub/probr#359 due to infrequent unexpected concurrency behavior `fatal: concurrent map writes`