### PR TITLE
Enabling step name for audit functions

### DIFF
--- a/audit/audit.go
+++ b/audit/audit.go
@@ -30,6 +30,7 @@ type ScenarioAudit struct {
 }
 
 type stepAudit struct {
+	Function    string
 	Name        string
 	Description string      // Long-form explanation of anything happening in the step
 	Result      string      // Passed / Failed
@@ -60,9 +61,46 @@ func (p *ScenarioAudit) AuditScenarioStep(description string, payload interface{
 	p.audit(stepName, description, payload, err)
 }
 
+// AuditScenarioStep2 sets description, payload, and pass/fail based on err parameter.
+// This function should be deferred to catch panic behavior, otherwise the audit will not be logged on panic
+func (p *ScenarioAudit) AuditScenarioStep2(stepName, description string, payload interface{}, err error) {
+	// TODO: This function should replace AuditScenarioStep. Added here to avoid breaking existing probes.
+	stepFunctionName := utils.CallerName(2) // returns name if deferred and not panicking
+	switch stepFunctionName {
+	case "call":
+		stepFunctionName = utils.CallerName(1) // returns name if this function was not deferred in the caller
+	case "gopanic":
+		stepFunctionName = utils.CallerName(3) // returns name if caller panicked and this function was deferred
+	}
+
+	p.audit2(stepFunctionName, stepName, description, payload, err)
+}
+
 func (p *ScenarioAudit) audit(stepName string, description string, payload interface{}, err error) {
 	stepNumber := len(p.Steps) + 1
 	p.Steps[stepNumber] = &stepAudit{
+		Name:        stepName,
+		Description: description,
+		Payload:     payload,
+	}
+	if err == nil {
+		p.Steps[stepNumber].Result = "Passed"
+		p.Result = "Passed"
+	} else {
+		p.Steps[stepNumber].Result = "Failed"
+		p.Steps[stepNumber].Error = strings.Replace(err.Error(), "[ERROR] ", "", -1)
+		if stepNumber == 1 {
+			p.Result = "Given Not Met" // First entry is always a 'given'; failures should be ignored
+		} else {
+			p.Result = "Failed" // First 'given' was met, but a subsequent step failed
+		}
+	}
+}
+func (p *ScenarioAudit) audit2(functionName string, stepName string, description string, payload interface{}, err error) {
+	// TODO: This function should replace audit. Added here to avoid breaking existing probes.
+	stepNumber := len(p.Steps) + 1
+	p.Steps[stepNumber] = &stepAudit{
+		Function:    functionName,
 		Name:        stepName,
 		Description: description,
 		Payload:     payload,

--- a/audit/audit.go
+++ b/audit/audit.go
@@ -50,21 +50,7 @@ func (e *ProbeAudit) Write() {
 
 // AuditScenarioStep sets description, payload, and pass/fail based on err parameter.
 // This function should be deferred to catch panic behavior, otherwise the audit will not be logged on panic
-func (p *ScenarioAudit) AuditScenarioStep(description string, payload interface{}, err error) {
-	stepName := utils.CallerName(2) // returns name if deferred and not panicking
-	switch stepName {
-	case "call":
-		stepName = utils.CallerName(1) // returns name if this function was not deferred in the caller
-	case "gopanic":
-		stepName = utils.CallerName(3) // returns name if caller panicked and this function was deferred
-	}
-	p.audit(stepName, description, payload, err)
-}
-
-// AuditScenarioStep2 sets description, payload, and pass/fail based on err parameter.
-// This function should be deferred to catch panic behavior, otherwise the audit will not be logged on panic
-func (p *ScenarioAudit) AuditScenarioStep2(stepName, description string, payload interface{}, err error) {
-	// TODO: This function should replace AuditScenarioStep. Added here to avoid breaking existing probes.
+func (p *ScenarioAudit) AuditScenarioStep(stepName, description string, payload interface{}, err error) {
 	stepFunctionName := utils.CallerName(2) // returns name if deferred and not panicking
 	switch stepFunctionName {
 	case "call":
@@ -73,30 +59,10 @@ func (p *ScenarioAudit) AuditScenarioStep2(stepName, description string, payload
 		stepFunctionName = utils.CallerName(3) // returns name if caller panicked and this function was deferred
 	}
 
-	p.audit2(stepFunctionName, stepName, description, payload, err)
+	p.audit(stepFunctionName, stepName, description, payload, err)
 }
 
-func (p *ScenarioAudit) audit(stepName string, description string, payload interface{}, err error) {
-	stepNumber := len(p.Steps) + 1
-	p.Steps[stepNumber] = &stepAudit{
-		Name:        stepName,
-		Description: description,
-		Payload:     payload,
-	}
-	if err == nil {
-		p.Steps[stepNumber].Result = "Passed"
-		p.Result = "Passed"
-	} else {
-		p.Steps[stepNumber].Result = "Failed"
-		p.Steps[stepNumber].Error = strings.Replace(err.Error(), "[ERROR] ", "", -1)
-		if stepNumber == 1 {
-			p.Result = "Given Not Met" // First entry is always a 'given'; failures should be ignored
-		} else {
-			p.Result = "Failed" // First 'given' was met, but a subsequent step failed
-		}
-	}
-}
-func (p *ScenarioAudit) audit2(functionName string, stepName string, description string, payload interface{}, err error) {
+func (p *ScenarioAudit) audit(functionName string, stepName string, description string, payload interface{}, err error) {
 	// TODO: This function should replace audit. Added here to avoid breaking existing probes.
 	stepNumber := len(p.Steps) + 1
 	p.Steps[stepNumber] = &stepAudit{

--- a/service_packs/apim/azure/endpoint_security/endpoint_security.go
+++ b/service_packs/apim/azure/endpoint_security/endpoint_security.go
@@ -62,7 +62,7 @@ func (s *scenarioState) anAPIIsDeployedToAPIM() error {
 	payload := struct {
 	}{}
 	defer func() {
-		s.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep(s.currentStep, stepTrace.String(), payload, err)
 	}()
 	err = fmt.Errorf("Not Implemented")
 	stepTrace.WriteString("TODO: Pending implementation;")
@@ -79,7 +79,7 @@ func (s *scenarioState) eachEndpointHasMTLSEmabled() error {
 	payload := struct {
 	}{}
 	defer func() {
-		s.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep(s.currentStep, stepTrace.String(), payload, err)
 	}()
 	err = fmt.Errorf("Not Implemented")
 	stepTrace.WriteString("TODO: Pending implementation;")
@@ -96,7 +96,7 @@ func (s *scenarioState) allEndpointsAreRetrievedFromAPIM() error {
 	payload := struct {
 	}{}
 	defer func() {
-		s.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep(s.currentStep, stepTrace.String(), payload, err)
 	}()
 	err = fmt.Errorf("Not Implemented")
 	stepTrace.WriteString("TODO: Pending implementation;")

--- a/service_packs/apim/azure/endpoint_security/endpoint_security.go
+++ b/service_packs/apim/azure/endpoint_security/endpoint_security.go
@@ -11,10 +11,11 @@ import (
 )
 
 type scenarioState struct {
-	name  string
-	audit *audit.ScenarioAudit
-	probe *audit.Probe
-	ctx   context.Context
+	name        string
+	currentStep string
+	audit       *audit.ScenarioAudit
+	probe       *audit.Probe
+	ctx         context.Context
 }
 
 // ProbeStruct allows this probe to be added to the ProbeStore
@@ -117,5 +118,13 @@ func (p ProbeStruct) ScenarioInitialize(ctx *godog.ScenarioContext) {
 
 	ctx.AfterScenario(func(s *godog.Scenario, err error) {
 		coreengine.LogScenarioEnd(s)
+	})
+
+	ctx.BeforeStep(func(st *godog.Step) {
+		p.state.currentStep = st.Text
+	})
+
+	ctx.AfterStep(func(st *godog.Step, err error) {
+		p.state.currentStep = ""
 	})
 }

--- a/service_packs/kubernetes/container_registry_access/container_registry_access.go
+++ b/service_packs/kubernetes/container_registry_access/container_registry_access.go
@@ -34,7 +34,7 @@ func (s *scenarioState) aKubernetesClusterIsDeployed() error {
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep(s.currentStep, stepTrace.String(), payload, err)
 	}()
 	description, payload, err := kubernetes.ClusterIsDeployed()
 	stepTrace.WriteString(description)
@@ -47,7 +47,7 @@ func (s *scenarioState) iAmAuthorisedToPullFromAContainerRegistry() error {
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	// TODO: We are assuming too much here- if the image successfully pulls but fails to build, this will still fail
@@ -69,7 +69,7 @@ func (s *scenarioState) theDeploymentAttemptIsAllowed() error {
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	// TODO: Extending the comment in iAmAuthorisedToPullFromAContainerRegistry...
@@ -89,7 +89,7 @@ func (s *scenarioState) aUserAttemptsToDeployUnauthorisedContainer() error {
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	pod, podAudit, err := cra.SetupContainerAccessProbePod(config.Vars.ServicePacks.Kubernetes.UnauthorisedContainerRegistry, s.probe)
@@ -113,7 +113,7 @@ func (s *scenarioState) theDeploymentAttemptIsDenied() error {
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	err = kubernetes.AssertResult(&s.podState, "denied", "")
@@ -173,5 +173,13 @@ func (p probeStruct) ScenarioInitialize(ctx *godog.ScenarioContext) {
 		cra.TeardownContainerAccessProbePod(ps.podState.PodName, p.Name())
 
 		coreengine.LogScenarioEnd(s)
+	})
+
+	ctx.BeforeStep(func(st *godog.Step) {
+		ps.currentStep = st.Text
+	})
+
+	ctx.AfterStep(func(st *godog.Step, err error) {
+		ps.currentStep = ""
 	})
 }

--- a/service_packs/kubernetes/container_registry_access/helpers.go
+++ b/service_packs/kubernetes/container_registry_access/helpers.go
@@ -29,10 +29,11 @@ type CRA struct {
 }
 
 type scenarioState struct {
-	name     string
-	audit    *audit.ScenarioAudit
-	probe    *audit.Probe
-	podState kubernetes.PodState
+	name        string
+	currentStep string
+	audit       *audit.ScenarioAudit
+	probe       *audit.Probe
+	podState    kubernetes.PodState
 }
 
 // NewCRA creates a new CRA with the supplied kubernetes instance.

--- a/service_packs/kubernetes/general/general.go
+++ b/service_packs/kubernetes/general/general.go
@@ -28,7 +28,7 @@ var Probe probeStruct
 func (s *scenarioState) aKubernetesClusterIsDeployed() error {
 	description, payload, error := kubernetes.ClusterIsDeployed()
 	defer func() {
-		s.audit.AuditScenarioStep(description, payload, error)
+		s.audit.AuditScenarioStep2(s.currentStep, description, payload, error)
 	}()
 	return error //  ClusterIsDeployed will create a fatal error if kubeconfig doesn't validate
 }
@@ -39,7 +39,7 @@ func (s *scenarioState) iInspectTheThatAreConfigured(roleLevel string) error {
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
 		// Standard auditing logic to ensures panics are also audited
-		s.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep2(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	if roleLevel == "Cluster Roles" {
@@ -68,7 +68,7 @@ func (s *scenarioState) iShouldOnlyFindWildcardsInKnownAndAuthorisedConfiguratio
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep2(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	//we strip out system/known entries in the cluster roles & roles call
@@ -102,7 +102,7 @@ func (s *scenarioState) iAttemptToCreateADeploymentWhichDoesNotHaveASecurityCont
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep2(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	stepTrace.WriteString("Create unique pod name; ")
@@ -125,7 +125,7 @@ func (s *scenarioState) theDeploymentIsRejected() error {
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep2(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	//looking for a non-nil creation error
@@ -154,7 +154,7 @@ func (s *scenarioState) iShouldNotBeAbleToAccessTheKubernetesWebUI() error {
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep2(s.currentStep, stepTrace.String(), payload, err)
 	}()
 	stepTrace.WriteString("PENDING IMPLEMENTATION")
 	return godog.ErrPending
@@ -164,7 +164,7 @@ func (s *scenarioState) theKubernetesWebUIIsDisabled() error {
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep2(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	kubeSystemNamespace := config.Vars.ServicePacks.Kubernetes.SystemNamespace
@@ -213,7 +213,7 @@ func (s *scenarioState) aPodIsDeployedInTheCluster() error {
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep2(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	var podAudit *kubernetes.PodAudit
@@ -246,7 +246,7 @@ func (s *scenarioState) aProcessInsideThePodEstablishesADirectHTTPSConnectionTo(
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep2(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	code, err := na.AccessURL(&s.podName, &url)
@@ -272,7 +272,7 @@ func (s *scenarioState) accessIs(accessResult string) error {
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep2(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	if accessResult == "blocked" {
@@ -340,5 +340,13 @@ func (p probeStruct) ScenarioInitialize(ctx *godog.ScenarioContext) {
 	ctx.AfterScenario(func(s *godog.Scenario, err error) {
 		kubernetes.GetKubeInstance().DeletePod(ps.podState.PodName, kubernetes.Namespace, p.Name())
 		coreengine.LogScenarioEnd(s)
+	})
+
+	ctx.BeforeStep(func(st *godog.Step) {
+		ps.currentStep = st.Text
+	})
+
+	ctx.AfterStep(func(st *godog.Step, err error) {
+		ps.currentStep = ""
 	})
 }

--- a/service_packs/kubernetes/general/general.go
+++ b/service_packs/kubernetes/general/general.go
@@ -28,7 +28,7 @@ var Probe probeStruct
 func (s *scenarioState) aKubernetesClusterIsDeployed() error {
 	description, payload, error := kubernetes.ClusterIsDeployed()
 	defer func() {
-		s.audit.AuditScenarioStep2(s.currentStep, description, payload, error)
+		s.audit.AuditScenarioStep(s.currentStep, description, payload, error)
 	}()
 	return error //  ClusterIsDeployed will create a fatal error if kubeconfig doesn't validate
 }
@@ -39,7 +39,7 @@ func (s *scenarioState) iInspectTheThatAreConfigured(roleLevel string) error {
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
 		// Standard auditing logic to ensures panics are also audited
-		s.audit.AuditScenarioStep2(s.currentStep, stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	if roleLevel == "Cluster Roles" {
@@ -68,7 +68,7 @@ func (s *scenarioState) iShouldOnlyFindWildcardsInKnownAndAuthorisedConfiguratio
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep2(s.currentStep, stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	//we strip out system/known entries in the cluster roles & roles call
@@ -102,7 +102,7 @@ func (s *scenarioState) iAttemptToCreateADeploymentWhichDoesNotHaveASecurityCont
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep2(s.currentStep, stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	stepTrace.WriteString("Create unique pod name; ")
@@ -125,7 +125,7 @@ func (s *scenarioState) theDeploymentIsRejected() error {
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep2(s.currentStep, stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	//looking for a non-nil creation error
@@ -154,7 +154,7 @@ func (s *scenarioState) iShouldNotBeAbleToAccessTheKubernetesWebUI() error {
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep2(s.currentStep, stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep(s.currentStep, stepTrace.String(), payload, err)
 	}()
 	stepTrace.WriteString("PENDING IMPLEMENTATION")
 	return godog.ErrPending
@@ -164,7 +164,7 @@ func (s *scenarioState) theKubernetesWebUIIsDisabled() error {
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep2(s.currentStep, stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	kubeSystemNamespace := config.Vars.ServicePacks.Kubernetes.SystemNamespace
@@ -213,7 +213,7 @@ func (s *scenarioState) aPodIsDeployedInTheCluster() error {
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep2(s.currentStep, stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	var podAudit *kubernetes.PodAudit
@@ -246,7 +246,7 @@ func (s *scenarioState) aProcessInsideThePodEstablishesADirectHTTPSConnectionTo(
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep2(s.currentStep, stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	code, err := na.AccessURL(&s.podName, &url)
@@ -272,7 +272,7 @@ func (s *scenarioState) accessIs(accessResult string) error {
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep2(s.currentStep, stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	if accessResult == "blocked" {

--- a/service_packs/kubernetes/general/helpers.go
+++ b/service_packs/kubernetes/general/helpers.go
@@ -21,6 +21,7 @@ const (
 
 type scenarioState struct {
 	name           string
+	currentStep    string
 	audit          *audit.ScenarioAudit
 	probe          *audit.Probe
 	podState       kubernetes.PodState

--- a/service_packs/kubernetes/iam/helpers.go
+++ b/service_packs/kubernetes/iam/helpers.go
@@ -21,6 +21,7 @@ import (
 
 type scenarioState struct {
 	name         string
+	currentStep  string
 	audit        *audit.ScenarioAudit
 	probe        *audit.Probe
 	podState     kubernetes.PodState

--- a/service_packs/kubernetes/iam/iam.go
+++ b/service_packs/kubernetes/iam/iam.go
@@ -56,7 +56,7 @@ func (s *scenarioState) aKubernetesClusterIsDeployed() error {
 	description, payload, err := kubernetes.ClusterIsDeployed()
 	stepTrace.WriteString(description)
 	defer func() {
-		s.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep2(s.currentStep, stepTrace.String(), payload, err)
 	}()
 	return err //  ClusterIsDeployed will create a fatal error if kubeconfig doesn't validate
 }
@@ -66,7 +66,7 @@ func (s *scenarioState) aNamedAzureIdentityBindingExistsInNamedNS(aibName string
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep2(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	stepTrace.WriteString(fmt.Sprintf(
@@ -80,7 +80,7 @@ func (s *scenarioState) iCreateASimplePodInNamespaceAssignedWithThatAzureIdentit
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep2(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	specPath := "iam-azi-test-aib-curl.yaml"
@@ -112,7 +112,7 @@ func (s *scenarioState) thePodIsDeployedSuccessfully() error {
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep2(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	stepTrace.WriteString("Validate that the pod was deployed successfully; ")
@@ -145,7 +145,7 @@ func (s *scenarioState) anAttemptToObtainAnAccessTokenFromThatPodShould(expected
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep2(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	// TODO: Pod creation is checked in previous step. This may not be necessary.
@@ -195,7 +195,7 @@ func (s *scenarioState) aNamedAzureIdentityExistsInNamedNS(namespace string, aiN
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep2(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	stepTrace.WriteString(fmt.Sprintf(
@@ -215,7 +215,7 @@ func (s *scenarioState) iCreateAnAzureIdentityBindingCalledInANondefaultNamespac
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep2(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	stepTrace.WriteString(fmt.Sprintf(
@@ -236,7 +236,7 @@ func (s *scenarioState) iDeployAPodAssignedWithTheAzureIdentityBindingIntoThePro
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep2(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	specPath := "iam-azi-test-aib-curl.yaml"
@@ -268,7 +268,7 @@ func (s *scenarioState) theClusterHasManagedIdentityComponentsDeployed() error {
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep2(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	stepTrace.WriteString(fmt.Sprintf(
@@ -308,7 +308,7 @@ func (s *scenarioState) iExecuteTheCommandAgainstTheMICPod(arg1 string) error {
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep2(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	stepTrace.WriteString(fmt.Sprintf(
@@ -344,7 +344,7 @@ func (s *scenarioState) kubernetesShouldPreventMeFromRunningTheCommand() error {
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep2(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	stepTrace.WriteString("Examine scenario state to ensure that verification command exit code was not 0; ")
@@ -429,5 +429,13 @@ func (p probeStruct) ScenarioInitialize(ctx *godog.ScenarioContext) {
 	ctx.AfterScenario(func(s *godog.Scenario, err error) {
 		iam.DeleteIAMProbePod(ps.podState.PodName, ps.useDefaultNS, p.Name())
 		coreengine.LogScenarioEnd(s)
+	})
+
+	ctx.BeforeStep(func(st *godog.Step) {
+		ps.currentStep = st.Text
+	})
+
+	ctx.AfterStep(func(st *godog.Step, err error) {
+		ps.currentStep = ""
 	})
 }

--- a/service_packs/kubernetes/iam/iam.go
+++ b/service_packs/kubernetes/iam/iam.go
@@ -56,7 +56,7 @@ func (s *scenarioState) aKubernetesClusterIsDeployed() error {
 	description, payload, err := kubernetes.ClusterIsDeployed()
 	stepTrace.WriteString(description)
 	defer func() {
-		s.audit.AuditScenarioStep2(s.currentStep, stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep(s.currentStep, stepTrace.String(), payload, err)
 	}()
 	return err //  ClusterIsDeployed will create a fatal error if kubeconfig doesn't validate
 }
@@ -66,7 +66,7 @@ func (s *scenarioState) aNamedAzureIdentityBindingExistsInNamedNS(aibName string
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep2(s.currentStep, stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	stepTrace.WriteString(fmt.Sprintf(
@@ -80,7 +80,7 @@ func (s *scenarioState) iCreateASimplePodInNamespaceAssignedWithThatAzureIdentit
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep2(s.currentStep, stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	specPath := "iam-azi-test-aib-curl.yaml"
@@ -112,7 +112,7 @@ func (s *scenarioState) thePodIsDeployedSuccessfully() error {
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep2(s.currentStep, stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	stepTrace.WriteString("Validate that the pod was deployed successfully; ")
@@ -145,7 +145,7 @@ func (s *scenarioState) anAttemptToObtainAnAccessTokenFromThatPodShould(expected
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep2(s.currentStep, stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	// TODO: Pod creation is checked in previous step. This may not be necessary.
@@ -195,7 +195,7 @@ func (s *scenarioState) aNamedAzureIdentityExistsInNamedNS(namespace string, aiN
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep2(s.currentStep, stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	stepTrace.WriteString(fmt.Sprintf(
@@ -215,7 +215,7 @@ func (s *scenarioState) iCreateAnAzureIdentityBindingCalledInANondefaultNamespac
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep2(s.currentStep, stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	stepTrace.WriteString(fmt.Sprintf(
@@ -236,7 +236,7 @@ func (s *scenarioState) iDeployAPodAssignedWithTheAzureIdentityBindingIntoThePro
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep2(s.currentStep, stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	specPath := "iam-azi-test-aib-curl.yaml"
@@ -268,7 +268,7 @@ func (s *scenarioState) theClusterHasManagedIdentityComponentsDeployed() error {
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep2(s.currentStep, stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	stepTrace.WriteString(fmt.Sprintf(
@@ -308,7 +308,7 @@ func (s *scenarioState) iExecuteTheCommandAgainstTheMICPod(arg1 string) error {
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep2(s.currentStep, stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	stepTrace.WriteString(fmt.Sprintf(
@@ -344,7 +344,7 @@ func (s *scenarioState) kubernetesShouldPreventMeFromRunningTheCommand() error {
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep2(s.currentStep, stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	stepTrace.WriteString("Examine scenario state to ensure that verification command exit code was not 0; ")

--- a/service_packs/kubernetes/old_pod_security_policy/helpers.go
+++ b/service_packs/kubernetes/old_pod_security_policy/helpers.go
@@ -33,12 +33,13 @@ const (
 type ProbeCommand int
 
 type scenarioState struct {
-	name      string
-	audit     *audit.ScenarioAudit
-	probe     *audit.Probe
-	podState  kubernetes.PodState
-	podStates []kubernetes.PodState
-	info      []interface{} //used to pass arbitrary information between steps
+	name        string
+	currentStep string
+	audit       *audit.ScenarioAudit
+	probe       *audit.Probe
+	podState    kubernetes.PodState
+	podStates   []kubernetes.PodState
+	info        []interface{} //used to pass arbitrary information between steps
 }
 
 // VerificationProbe encapsulates the command and expected result to be used in a Pod Security Policy probe.

--- a/service_packs/kubernetes/old_pod_security_policy/pod_security_policy.go
+++ b/service_packs/kubernetes/old_pod_security_policy/pod_security_policy.go
@@ -33,7 +33,7 @@ func (s *scenarioState) creationWillWithAMessage(arg1, arg2 string) error {
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep(s.currentStep, stepTrace.String(), payload, err)
 	}()
 	stepTrace.WriteString("PENDING IMPLEMENTATION")
 	return godog.ErrPending
@@ -44,7 +44,7 @@ func (s *scenarioState) aKubernetesClusterIsDeployed() error {
 	description, payload, err := kubernetes.ClusterIsDeployed()
 	stepTrace.WriteString(description)
 	defer func() {
-		s.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep(s.currentStep, stepTrace.String(), payload, err)
 	}()
 	return err //  ClusterIsDeployed will create a fatal error if kubeconfig doesn't validate
 }
@@ -54,7 +54,7 @@ func (s *scenarioState) aKubernetesDeploymentIsAppliedToAnExistingKubernetesClus
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	//TODO: not sure this step is adding value ... return "pass" for now ...
@@ -67,7 +67,7 @@ func (s *scenarioState) theOperationWillWithAnError(result, message string) erro
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	stepTrace.WriteString("Validate that the scenario state was updated in the previous step with a particular result and message; ")
@@ -85,7 +85,7 @@ func (s *scenarioState) allOperationsWillWithAnError(result, message string) err
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	var kubeErrors []error
@@ -113,7 +113,7 @@ func (s *scenarioState) iShouldBeAbleToPerformAnAllowedCommand() error {
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	if len(s.podStates) == 0 {
@@ -292,7 +292,7 @@ func (s *scenarioState) privilegedAccessRequestIsMarkedForTheKubernetesDeploymen
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	var pa bool
@@ -318,7 +318,7 @@ func (s *scenarioState) someControlExistsToPreventPrivilegedAccessForKubernetesD
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	// TODO: This entire process needs refactored for readability, and to remove holistic dependency on azure security context
@@ -336,7 +336,7 @@ func (s *scenarioState) iShouldNotBeAbleToPerformACommandThatRequiresPrivilegedA
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	stepTrace.WriteString(fmt.Sprintf(
@@ -356,7 +356,7 @@ func (s *scenarioState) hostPIDRequestIsMarkedForTheKubernetesDeployment(hostPID
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	var hostPID bool
@@ -381,7 +381,7 @@ func (s *scenarioState) someSystemExistsToPreventAKubernetesContainerFromRunning
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	stepTrace.WriteString("Validate that at least on of the cluster's pod security policies has HostPID set to false; ")
@@ -398,7 +398,7 @@ func (s *scenarioState) iShouldNotBeAbleToPerformACommandThatProvidesAccessToThe
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	stepTrace.WriteString(fmt.Sprintf(
@@ -417,7 +417,7 @@ func (s *scenarioState) hostIPCRequestIsMarkedForTheKubernetesDeployment(hostIPC
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	var hostIPC bool
@@ -443,7 +443,7 @@ func (s *scenarioState) someSystemExistsToPreventAKubernetesDeploymentFromRunnin
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	stepTrace.WriteString("Validate that at least on of the cluster's pod security policies has HostIPC set to false; ")
@@ -460,7 +460,7 @@ func (s *scenarioState) iShouldNotBeAbleToPerformACommandThatProvidesAccessToThe
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	stepTrace.WriteString(fmt.Sprintf(
@@ -479,7 +479,7 @@ func (s *scenarioState) hostNetworkRequestIsMarkedForTheKubernetesDeployment(hos
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	var hostNetwork bool
@@ -505,7 +505,7 @@ func (s *scenarioState) someSystemExistsToPreventAKubernetesDeploymentFromRunnin
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	stepTrace.WriteString("Validate that at least on of the pod security policies has HostNetwork set to false; ")
@@ -522,7 +522,7 @@ func (s *scenarioState) iShouldNotBeAbleToPerformACommandThatProvidesAccessToThe
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	stepTrace.WriteString(fmt.Sprintf(
@@ -541,7 +541,7 @@ func (s *scenarioState) privilegedEscalationIsMarkedForTheKubernetesDeployment(p
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	allowPrivilegeEscalation := "true"
@@ -571,7 +571,7 @@ func (s *scenarioState) someSystemExistsToPreventAKubernetesDeploymentFromRunnin
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	stepTrace.WriteString(
@@ -589,7 +589,7 @@ func (s *scenarioState) iShouldNotBeAbleToPerformASudoCommandThatRequiresPrivile
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	stepTrace.WriteString(fmt.Sprintf(
@@ -608,7 +608,7 @@ func (s *scenarioState) theUserRequestedIsForTheKubernetesDeployment(requestedUs
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	var runAsUser int64
@@ -634,7 +634,7 @@ func (s *scenarioState) someSystemExistsToPreventAKubernetesDeploymentFromRunnin
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	stepTrace.WriteString(
@@ -652,7 +652,7 @@ func (s *scenarioState) theKubernetesDeploymentShouldRunWithANonrootUID() error 
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	stepTrace.WriteString(fmt.Sprintf(
@@ -670,7 +670,7 @@ func (s *scenarioState) kubernetesDeploymentWithNETRAWCapability(netRawRequested
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	var capAdd, capDrop []string
@@ -702,7 +702,7 @@ func (s *scenarioState) iShouldNotBeAbleToPerformACommandThatRequiresNETRAWCapab
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	stepTrace.WriteString(fmt.Sprintf(
@@ -721,7 +721,7 @@ func (s *scenarioState) additionalCapabilitiesForTheKubernetesDeployment(capabil
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	var capabilities []string
@@ -789,7 +789,7 @@ func (s *scenarioState) someSystemExistsToPreventKubernetesDeploymentsWithCapabi
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	stepTrace.WriteString("Validate that no pod security policies have any values in AllowedCapabilities; ")
@@ -806,7 +806,7 @@ func (s *scenarioState) iShouldNotBeAbleToPerformACommandThatRequiresCapabilitie
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	stepTrace.WriteString(
@@ -826,7 +826,7 @@ func (s *scenarioState) assignedCapabilitiesForTheKubernetesDeployment(assignCap
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	var c []string
@@ -857,7 +857,7 @@ func (s *scenarioState) someSystemExistsToPreventKubernetesDeploymentsWithAssign
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	stepTrace.WriteString("Validate that the kube instance security context contains 'k8sazureallowedcapabilities'; ")
@@ -874,7 +874,7 @@ func (s *scenarioState) iShouldNotBeAbleToPerformACommandThatRequiresAnyCapabili
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	stepTrace.WriteString(fmt.Sprintf(
@@ -893,7 +893,7 @@ func (s *scenarioState) anPortRangeIsRequestedForTheKubernetesDeployment(portRan
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	var y []byte
@@ -939,7 +939,7 @@ func (s *scenarioState) someSystemExistsToPreventKubernetesDeploymentsWithUnappr
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	stepTrace.WriteString("Validate that the kube instance security context contains 'k8sazurehostnetworkingports'; ")
@@ -956,7 +956,7 @@ func (s *scenarioState) iShouldNotBeAbleToPerformACommandThatAccessAnUnapprovedP
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	stepTrace.WriteString(fmt.Sprintf(
@@ -975,7 +975,7 @@ func (s *scenarioState) volumeTypesAreRequestedForTheKubernetesDeployment(volume
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	var volumeTypes []string
@@ -1031,7 +1031,7 @@ func (s *scenarioState) someSystemExistsToPreventKubernetesDeploymentsWithUnappr
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	stepTrace.WriteString("Validate that the kube instance security context contains 'k8sazurevolumetypes'; ")
@@ -1050,7 +1050,7 @@ func (s *scenarioState) iShouldNotBeAbleToPerformACommandThatAccessesAnUnapprove
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	stepTrace.WriteString("PENDING IMPLEMENTATION")
@@ -1063,7 +1063,7 @@ func (s *scenarioState) anSeccompProfileIsRequestedForTheKubernetesDeployment(se
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	var y []byte
@@ -1099,7 +1099,7 @@ func (s *scenarioState) someSystemExistsToPreventKubernetesDeploymentsWithoutApp
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	stepTrace.WriteString("Validate that the kube instance security context contains 'k8sazureallowedseccomp'; ")
@@ -1116,7 +1116,7 @@ func (s *scenarioState) iShouldNotBeAbleToPerformASystemCallThatIsBlockedByTheSe
 	// Standard auditing logic to ensures panics are also audited
 	stepTrace, payload, err := utils.AuditPlaceholders()
 	defer func() {
-		s.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		s.audit.AuditScenarioStep(s.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	stepTrace.WriteString(fmt.Sprintf(
@@ -1249,5 +1249,13 @@ func (p probeStruct) ScenarioInitialize(ctx *godog.ScenarioContext) {
 		ps.podState.PodName = ""
 		ps.podState.CreationError = nil
 		coreengine.LogScenarioEnd(s)
+	})
+
+	ctx.BeforeStep(func(st *godog.Step) {
+		ps.currentStep = st.Text
+	})
+
+	ctx.AfterStep(func(st *godog.Step, err error) {
+		ps.currentStep = ""
 	})
 }

--- a/service_packs/storage/azure/access_whitelisting/access_whitelisting.go
+++ b/service_packs/storage/azure/access_whitelisting/access_whitelisting.go
@@ -72,7 +72,7 @@ func (state *scenarioState) anAzureResourceGroupExists() error {
 		AzureResourceGroup:  azureutil.ResourceGroup(),
 	}
 	defer func() {
-		state.audit.AuditScenarioStep2(state.currentStep, stepTrace.String(), payload, err)
+		state.audit.AuditScenarioStep(state.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	stepTrace.WriteString("Check if value for Azure resource group is set in config vars;")
@@ -102,7 +102,7 @@ func (state *scenarioState) checkPolicyAssigned() error {
 		PolicyAssignment     azurePolicy.Assignment
 	}{}
 	defer func() {
-		state.audit.AuditScenarioStep2(state.currentStep, stepTrace.String(), payload, err)
+		state.audit.AuditScenarioStep(state.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	var a azurePolicy.Assignment
@@ -140,7 +140,7 @@ func (state *scenarioState) provisionStorageContainer() error {
 		BucketName string
 	}{}
 	defer func() {
-		state.audit.AuditScenarioStep2(state.currentStep, stepTrace.String(), payload, err)
+		state.audit.AuditScenarioStep(state.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	stepTrace.WriteString("A bucket name is defined using a random string, storage account is not yet provisioned;")
@@ -166,7 +166,7 @@ func (state *scenarioState) createWithWhitelist(ipRange string) error {
 		StorageAccount azureStorage.Account
 	}{}
 	defer func() {
-		state.audit.AuditScenarioStep2(state.currentStep, stepTrace.String(), payload, err)
+		state.audit.AuditScenarioStep(state.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	stepTrace.WriteString(fmt.Sprintf(
@@ -217,7 +217,7 @@ func (state *scenarioState) creationWill(expectation string) error {
 		CreationError    string
 	}{}
 	defer func() {
-		state.audit.AuditScenarioStep2(state.currentStep, stepTrace.String(), payload, err)
+		state.audit.AuditScenarioStep(state.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	stepTrace.WriteString(fmt.Sprintf(
@@ -252,7 +252,7 @@ func (state *scenarioState) cspSupportsWhitelisting() error {
 	payload := struct {
 	}{}
 	defer func() {
-		state.audit.AuditScenarioStep2(state.currentStep, stepTrace.String(), payload, err)
+		state.audit.AuditScenarioStep(state.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	err = fmt.Errorf("Not Implemented")
@@ -273,7 +273,7 @@ func (state *scenarioState) examineStorageContainer(containerNameEnvVar string) 
 		NetworkRuleSet     azureStorage.NetworkRuleSet
 	}{}
 	defer func() {
-		state.audit.AuditScenarioStep2(state.currentStep, stepTrace.String(), payload, err)
+		state.audit.AuditScenarioStep(state.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	stepTrace.WriteString(fmt.Sprintf(
@@ -343,7 +343,7 @@ func (state *scenarioState) whitelistingIsConfigured() error {
 	payload := struct {
 	}{}
 	defer func() {
-		state.audit.AuditScenarioStep2(state.currentStep, stepTrace.String(), payload, err)
+		state.audit.AuditScenarioStep(state.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	err = fmt.Errorf("Not Implemented")

--- a/service_packs/storage/azure/access_whitelisting/access_whitelisting.go
+++ b/service_packs/storage/azure/access_whitelisting/access_whitelisting.go
@@ -38,6 +38,7 @@ var Probe ProbeStruct
 
 type scenarioState struct {
 	name                      string
+	currentStep               string
 	audit                     *audit.ScenarioAudit
 	probe                     *audit.Probe
 	ctx                       context.Context
@@ -71,7 +72,7 @@ func (state *scenarioState) anAzureResourceGroupExists() error {
 		AzureResourceGroup:  azureutil.ResourceGroup(),
 	}
 	defer func() {
-		state.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		state.audit.AuditScenarioStep2(state.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	stepTrace.WriteString("Check if value for Azure resource group is set in config vars;")
@@ -101,7 +102,7 @@ func (state *scenarioState) checkPolicyAssigned() error {
 		PolicyAssignment     azurePolicy.Assignment
 	}{}
 	defer func() {
-		state.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		state.audit.AuditScenarioStep2(state.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	var a azurePolicy.Assignment
@@ -139,7 +140,7 @@ func (state *scenarioState) provisionStorageContainer() error {
 		BucketName string
 	}{}
 	defer func() {
-		state.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		state.audit.AuditScenarioStep2(state.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	stepTrace.WriteString("A bucket name is defined using a random string, storage account is not yet provisioned;")
@@ -165,7 +166,7 @@ func (state *scenarioState) createWithWhitelist(ipRange string) error {
 		StorageAccount azureStorage.Account
 	}{}
 	defer func() {
-		state.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		state.audit.AuditScenarioStep2(state.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	stepTrace.WriteString(fmt.Sprintf(
@@ -216,7 +217,7 @@ func (state *scenarioState) creationWill(expectation string) error {
 		CreationError    string
 	}{}
 	defer func() {
-		state.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		state.audit.AuditScenarioStep2(state.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	stepTrace.WriteString(fmt.Sprintf(
@@ -251,7 +252,7 @@ func (state *scenarioState) cspSupportsWhitelisting() error {
 	payload := struct {
 	}{}
 	defer func() {
-		state.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		state.audit.AuditScenarioStep2(state.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	err = fmt.Errorf("Not Implemented")
@@ -272,7 +273,7 @@ func (state *scenarioState) examineStorageContainer(containerNameEnvVar string) 
 		NetworkRuleSet     azureStorage.NetworkRuleSet
 	}{}
 	defer func() {
-		state.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		state.audit.AuditScenarioStep2(state.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	stepTrace.WriteString(fmt.Sprintf(
@@ -342,7 +343,7 @@ func (state *scenarioState) whitelistingIsConfigured() error {
 	payload := struct {
 	}{}
 	defer func() {
-		state.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		state.audit.AuditScenarioStep2(state.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	err = fmt.Errorf("Not Implemented")
@@ -400,5 +401,13 @@ func (p ProbeStruct) ScenarioInitialize(ctx *godog.ScenarioContext) {
 
 	ctx.AfterScenario(func(s *godog.Scenario, err error) {
 		coreengine.LogScenarioEnd(s)
+	})
+
+	ctx.BeforeStep(func(st *godog.Step) {
+		p.state.currentStep = st.Text
+	})
+
+	ctx.AfterStep(func(st *godog.Step, err error) {
+		p.state.currentStep = ""
 	})
 }

--- a/service_packs/storage/azure/encryption_at_rest/encryption_at_rest.go
+++ b/service_packs/storage/azure/encryption_at_rest/encryption_at_rest.go
@@ -13,6 +13,7 @@ import (
 
 type scenarioState struct {
 	name                      string
+	currentStep               string
 	audit                     *audit.ScenarioAudit
 	probe                     *audit.Probe
 	ctx                       context.Context
@@ -37,7 +38,7 @@ func (state *scenarioState) securityControlsThatRestrictDataFromBeingUnencrypted
 	payload := struct {
 	}{}
 	defer func() {
-		state.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		state.audit.AuditScenarioStep2(state.currentStep, stepTrace.String(), payload, err)
 	}()
 	err = fmt.Errorf("Not Implemented")
 	stepTrace.WriteString("TODO: Pending implementation;")
@@ -56,7 +57,7 @@ func (state *scenarioState) weProvisionAnObjectStorageBucket() error {
 	payload := struct {
 	}{}
 	defer func() {
-		state.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		state.audit.AuditScenarioStep2(state.currentStep, stepTrace.String(), payload, err)
 	}()
 	err = fmt.Errorf("Not Implemented")
 	stepTrace.WriteString("TODO: Pending implementation;")
@@ -72,7 +73,7 @@ func (state *scenarioState) encryptionAtRestIs(encryptionOption string) error {
 	payload := struct {
 	}{}
 	defer func() {
-		state.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		state.audit.AuditScenarioStep2(state.currentStep, stepTrace.String(), payload, err)
 	}()
 	err = fmt.Errorf("Not Implemented")
 	stepTrace.WriteString("TODO: Pending implementation;")
@@ -88,7 +89,7 @@ func (state *scenarioState) creationWillWithAnErrorMatching(result string) error
 	payload := struct {
 	}{}
 	defer func() {
-		state.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		state.audit.AuditScenarioStep2(state.currentStep, stepTrace.String(), payload, err)
 	}()
 	err = fmt.Errorf("Not Implemented")
 	stepTrace.WriteString("TODO: Pending implementation;")
@@ -104,7 +105,7 @@ func (state *scenarioState) createContainerWithoutEncryption() error {
 	payload := struct {
 	}{}
 	defer func() {
-		state.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		state.audit.AuditScenarioStep2(state.currentStep, stepTrace.String(), payload, err)
 	}()
 	err = fmt.Errorf("Not Implemented")
 	stepTrace.WriteString("TODO: Pending implementation;")
@@ -120,7 +121,7 @@ func (state *scenarioState) detectiveDetectsNonCompliant() error {
 	payload := struct {
 	}{}
 	defer func() {
-		state.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		state.audit.AuditScenarioStep2(state.currentStep, stepTrace.String(), payload, err)
 	}()
 	err = fmt.Errorf("Not Implemented")
 	stepTrace.WriteString("TODO: Pending implementation;")
@@ -136,7 +137,7 @@ func (state *scenarioState) containerIsRemediated() error {
 	payload := struct {
 	}{}
 	defer func() {
-		state.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		state.audit.AuditScenarioStep2(state.currentStep, stepTrace.String(), payload, err)
 	}()
 	err = fmt.Errorf("Not Implemented")
 	stepTrace.WriteString("TODO: Pending implementation;")
@@ -160,7 +161,7 @@ func (state *scenarioState) policyOrRuleAvailable() error {
 	payload := struct {
 	}{}
 	defer func() {
-		state.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		state.audit.AuditScenarioStep2(state.currentStep, stepTrace.String(), payload, err)
 	}()
 	err = fmt.Errorf("Not Implemented")
 	stepTrace.WriteString("TODO: Pending implementation;")
@@ -178,7 +179,7 @@ func (state *scenarioState) checkPolicyOrRuleAssignment() error {
 	payload := struct {
 	}{}
 	defer func() {
-		state.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		state.audit.AuditScenarioStep2(state.currentStep, stepTrace.String(), payload, err)
 	}()
 	err = fmt.Errorf("Not Implemented")
 	stepTrace.WriteString("TODO: Pending implementation;")
@@ -194,7 +195,7 @@ func (state *scenarioState) policyOrRuleAssigned() error {
 	payload := struct {
 	}{}
 	defer func() {
-		state.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		state.audit.AuditScenarioStep2(state.currentStep, stepTrace.String(), payload, err)
 	}()
 	err = fmt.Errorf("Not Implemented")
 	stepTrace.WriteString("TODO: Pending implementation;")
@@ -266,5 +267,13 @@ func (p ProbeStruct) ScenarioInitialize(ctx *godog.ScenarioContext) {
 
 	ctx.AfterScenario(func(s *godog.Scenario, err error) {
 		coreengine.LogScenarioEnd(s)
+	})
+
+	ctx.BeforeStep(func(st *godog.Step) {
+		p.state.currentStep = st.Text
+	})
+
+	ctx.AfterStep(func(st *godog.Step, err error) {
+		p.state.currentStep = ""
 	})
 }

--- a/service_packs/storage/azure/encryption_at_rest/encryption_at_rest.go
+++ b/service_packs/storage/azure/encryption_at_rest/encryption_at_rest.go
@@ -38,7 +38,7 @@ func (state *scenarioState) securityControlsThatRestrictDataFromBeingUnencrypted
 	payload := struct {
 	}{}
 	defer func() {
-		state.audit.AuditScenarioStep2(state.currentStep, stepTrace.String(), payload, err)
+		state.audit.AuditScenarioStep(state.currentStep, stepTrace.String(), payload, err)
 	}()
 	err = fmt.Errorf("Not Implemented")
 	stepTrace.WriteString("TODO: Pending implementation;")
@@ -57,7 +57,7 @@ func (state *scenarioState) weProvisionAnObjectStorageBucket() error {
 	payload := struct {
 	}{}
 	defer func() {
-		state.audit.AuditScenarioStep2(state.currentStep, stepTrace.String(), payload, err)
+		state.audit.AuditScenarioStep(state.currentStep, stepTrace.String(), payload, err)
 	}()
 	err = fmt.Errorf("Not Implemented")
 	stepTrace.WriteString("TODO: Pending implementation;")
@@ -73,7 +73,7 @@ func (state *scenarioState) encryptionAtRestIs(encryptionOption string) error {
 	payload := struct {
 	}{}
 	defer func() {
-		state.audit.AuditScenarioStep2(state.currentStep, stepTrace.String(), payload, err)
+		state.audit.AuditScenarioStep(state.currentStep, stepTrace.String(), payload, err)
 	}()
 	err = fmt.Errorf("Not Implemented")
 	stepTrace.WriteString("TODO: Pending implementation;")
@@ -89,7 +89,7 @@ func (state *scenarioState) creationWillWithAnErrorMatching(result string) error
 	payload := struct {
 	}{}
 	defer func() {
-		state.audit.AuditScenarioStep2(state.currentStep, stepTrace.String(), payload, err)
+		state.audit.AuditScenarioStep(state.currentStep, stepTrace.String(), payload, err)
 	}()
 	err = fmt.Errorf("Not Implemented")
 	stepTrace.WriteString("TODO: Pending implementation;")
@@ -105,7 +105,7 @@ func (state *scenarioState) createContainerWithoutEncryption() error {
 	payload := struct {
 	}{}
 	defer func() {
-		state.audit.AuditScenarioStep2(state.currentStep, stepTrace.String(), payload, err)
+		state.audit.AuditScenarioStep(state.currentStep, stepTrace.String(), payload, err)
 	}()
 	err = fmt.Errorf("Not Implemented")
 	stepTrace.WriteString("TODO: Pending implementation;")
@@ -121,7 +121,7 @@ func (state *scenarioState) detectiveDetectsNonCompliant() error {
 	payload := struct {
 	}{}
 	defer func() {
-		state.audit.AuditScenarioStep2(state.currentStep, stepTrace.String(), payload, err)
+		state.audit.AuditScenarioStep(state.currentStep, stepTrace.String(), payload, err)
 	}()
 	err = fmt.Errorf("Not Implemented")
 	stepTrace.WriteString("TODO: Pending implementation;")
@@ -137,7 +137,7 @@ func (state *scenarioState) containerIsRemediated() error {
 	payload := struct {
 	}{}
 	defer func() {
-		state.audit.AuditScenarioStep2(state.currentStep, stepTrace.String(), payload, err)
+		state.audit.AuditScenarioStep(state.currentStep, stepTrace.String(), payload, err)
 	}()
 	err = fmt.Errorf("Not Implemented")
 	stepTrace.WriteString("TODO: Pending implementation;")
@@ -161,7 +161,7 @@ func (state *scenarioState) policyOrRuleAvailable() error {
 	payload := struct {
 	}{}
 	defer func() {
-		state.audit.AuditScenarioStep2(state.currentStep, stepTrace.String(), payload, err)
+		state.audit.AuditScenarioStep(state.currentStep, stepTrace.String(), payload, err)
 	}()
 	err = fmt.Errorf("Not Implemented")
 	stepTrace.WriteString("TODO: Pending implementation;")
@@ -179,7 +179,7 @@ func (state *scenarioState) checkPolicyOrRuleAssignment() error {
 	payload := struct {
 	}{}
 	defer func() {
-		state.audit.AuditScenarioStep2(state.currentStep, stepTrace.String(), payload, err)
+		state.audit.AuditScenarioStep(state.currentStep, stepTrace.String(), payload, err)
 	}()
 	err = fmt.Errorf("Not Implemented")
 	stepTrace.WriteString("TODO: Pending implementation;")
@@ -195,7 +195,7 @@ func (state *scenarioState) policyOrRuleAssigned() error {
 	payload := struct {
 	}{}
 	defer func() {
-		state.audit.AuditScenarioStep2(state.currentStep, stepTrace.String(), payload, err)
+		state.audit.AuditScenarioStep(state.currentStep, stepTrace.String(), payload, err)
 	}()
 	err = fmt.Errorf("Not Implemented")
 	stepTrace.WriteString("TODO: Pending implementation;")

--- a/service_packs/storage/azure/encryption_in_flight/encryption_in_flight.go
+++ b/service_packs/storage/azure/encryption_in_flight/encryption_in_flight.go
@@ -72,7 +72,7 @@ func (state *scenarioState) anAzureResourceGroupExists() error {
 		AzureResourceGroup:  azureutil.ResourceGroup(),
 	}
 	defer func() {
-		state.audit.AuditScenarioStep2(state.currentStep, stepTrace.String(), payload, err)
+		state.audit.AuditScenarioStep(state.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	stepTrace.WriteString("Check if value for Azure resource group is set in config vars;")
@@ -97,7 +97,7 @@ func (state *scenarioState) weProvisionAnObjectStorageBucket() error {
 	payload := struct {
 	}{}
 	defer func() {
-		state.audit.AuditScenarioStep2(state.currentStep, stepTrace.String(), payload, err)
+		state.audit.AuditScenarioStep(state.currentStep, stepTrace.String(), payload, err)
 	}()
 	err = fmt.Errorf("Not Implemented")
 	stepTrace.WriteString("TODO: Pending implementation;")
@@ -113,7 +113,7 @@ func (state *scenarioState) httpAccessIs(arg1 string) error {
 	payload := struct {
 	}{}
 	defer func() {
-		state.audit.AuditScenarioStep2(state.currentStep, stepTrace.String(), payload, err)
+		state.audit.AuditScenarioStep(state.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	stepTrace.WriteString(fmt.Sprintf(
@@ -133,7 +133,7 @@ func (state *scenarioState) httpsAccessIs(arg1 string) error {
 	payload := struct {
 	}{}
 	defer func() {
-		state.audit.AuditScenarioStep2(state.currentStep, stepTrace.String(), payload, err)
+		state.audit.AuditScenarioStep(state.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	stepTrace.WriteString(fmt.Sprintf(
@@ -157,7 +157,7 @@ func (state *scenarioState) creationWillWithAnErrorMatching(expectation, errDesc
 		HTTPSOption    bool
 	}{}
 	defer func() {
-		state.audit.AuditScenarioStep2(state.currentStep, stepTrace.String(), payload, err)
+		state.audit.AuditScenarioStep(state.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	stepTrace.WriteString("Generating random value for account name;")
@@ -241,7 +241,7 @@ func (state *scenarioState) detectObjectStorageUnencryptedTransferAvailable() er
 	payload := struct {
 	}{}
 	defer func() {
-		state.audit.AuditScenarioStep2(state.currentStep, stepTrace.String(), payload, err)
+		state.audit.AuditScenarioStep(state.currentStep, stepTrace.String(), payload, err)
 	}()
 	err = fmt.Errorf("Not Implemented")
 	stepTrace.WriteString("TODO: Pending implementation;")
@@ -256,7 +256,7 @@ func (state *scenarioState) detectObjectStorageUnencryptedTransferEnabled() erro
 	payload := struct {
 	}{}
 	defer func() {
-		state.audit.AuditScenarioStep2(state.currentStep, stepTrace.String(), payload, err)
+		state.audit.AuditScenarioStep(state.currentStep, stepTrace.String(), payload, err)
 	}()
 	err = fmt.Errorf("Not Implemented")
 	stepTrace.WriteString("TODO: Pending implementation;")
@@ -271,7 +271,7 @@ func (state *scenarioState) createUnencryptedTransferObjectStorage() error {
 	payload := struct {
 	}{}
 	defer func() {
-		state.audit.AuditScenarioStep2(state.currentStep, stepTrace.String(), payload, err)
+		state.audit.AuditScenarioStep(state.currentStep, stepTrace.String(), payload, err)
 	}()
 	err = fmt.Errorf("Not Implemented")
 	stepTrace.WriteString("TODO: Pending implementation;")
@@ -286,7 +286,7 @@ func (state *scenarioState) detectsTheObjectStorage() error {
 	payload := struct {
 	}{}
 	defer func() {
-		state.audit.AuditScenarioStep2(state.currentStep, stepTrace.String(), payload, err)
+		state.audit.AuditScenarioStep(state.currentStep, stepTrace.String(), payload, err)
 	}()
 	err = fmt.Errorf("Not Implemented")
 	stepTrace.WriteString("TODO: Pending implementation;")
@@ -301,7 +301,7 @@ func (state *scenarioState) encryptedDataTrafficIsEnforced() error {
 	payload := struct {
 	}{}
 	defer func() {
-		state.audit.AuditScenarioStep2(state.currentStep, stepTrace.String(), payload, err)
+		state.audit.AuditScenarioStep(state.currentStep, stepTrace.String(), payload, err)
 	}()
 	err = fmt.Errorf("Not Implemented")
 	stepTrace.WriteString("TODO: Pending implementation;")

--- a/service_packs/storage/azure/encryption_in_flight/encryption_in_flight.go
+++ b/service_packs/storage/azure/encryption_in_flight/encryption_in_flight.go
@@ -22,6 +22,7 @@ import (
 
 type scenarioState struct {
 	name                      string
+	currentStep               string
 	audit                     *audit.ScenarioAudit
 	probe                     *audit.Probe
 	ctx                       context.Context
@@ -71,7 +72,7 @@ func (state *scenarioState) anAzureResourceGroupExists() error {
 		AzureResourceGroup:  azureutil.ResourceGroup(),
 	}
 	defer func() {
-		state.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		state.audit.AuditScenarioStep2(state.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	stepTrace.WriteString("Check if value for Azure resource group is set in config vars;")
@@ -96,7 +97,7 @@ func (state *scenarioState) weProvisionAnObjectStorageBucket() error {
 	payload := struct {
 	}{}
 	defer func() {
-		state.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		state.audit.AuditScenarioStep2(state.currentStep, stepTrace.String(), payload, err)
 	}()
 	err = fmt.Errorf("Not Implemented")
 	stepTrace.WriteString("TODO: Pending implementation;")
@@ -112,7 +113,7 @@ func (state *scenarioState) httpAccessIs(arg1 string) error {
 	payload := struct {
 	}{}
 	defer func() {
-		state.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		state.audit.AuditScenarioStep2(state.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	stepTrace.WriteString(fmt.Sprintf(
@@ -132,7 +133,7 @@ func (state *scenarioState) httpsAccessIs(arg1 string) error {
 	payload := struct {
 	}{}
 	defer func() {
-		state.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		state.audit.AuditScenarioStep2(state.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	stepTrace.WriteString(fmt.Sprintf(
@@ -156,7 +157,7 @@ func (state *scenarioState) creationWillWithAnErrorMatching(expectation, errDesc
 		HTTPSOption    bool
 	}{}
 	defer func() {
-		state.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		state.audit.AuditScenarioStep2(state.currentStep, stepTrace.String(), payload, err)
 	}()
 
 	stepTrace.WriteString("Generating random value for account name;")
@@ -240,7 +241,7 @@ func (state *scenarioState) detectObjectStorageUnencryptedTransferAvailable() er
 	payload := struct {
 	}{}
 	defer func() {
-		state.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		state.audit.AuditScenarioStep2(state.currentStep, stepTrace.String(), payload, err)
 	}()
 	err = fmt.Errorf("Not Implemented")
 	stepTrace.WriteString("TODO: Pending implementation;")
@@ -255,7 +256,7 @@ func (state *scenarioState) detectObjectStorageUnencryptedTransferEnabled() erro
 	payload := struct {
 	}{}
 	defer func() {
-		state.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		state.audit.AuditScenarioStep2(state.currentStep, stepTrace.String(), payload, err)
 	}()
 	err = fmt.Errorf("Not Implemented")
 	stepTrace.WriteString("TODO: Pending implementation;")
@@ -270,7 +271,7 @@ func (state *scenarioState) createUnencryptedTransferObjectStorage() error {
 	payload := struct {
 	}{}
 	defer func() {
-		state.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		state.audit.AuditScenarioStep2(state.currentStep, stepTrace.String(), payload, err)
 	}()
 	err = fmt.Errorf("Not Implemented")
 	stepTrace.WriteString("TODO: Pending implementation;")
@@ -285,7 +286,7 @@ func (state *scenarioState) detectsTheObjectStorage() error {
 	payload := struct {
 	}{}
 	defer func() {
-		state.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		state.audit.AuditScenarioStep2(state.currentStep, stepTrace.String(), payload, err)
 	}()
 	err = fmt.Errorf("Not Implemented")
 	stepTrace.WriteString("TODO: Pending implementation;")
@@ -300,7 +301,7 @@ func (state *scenarioState) encryptedDataTrafficIsEnforced() error {
 	payload := struct {
 	}{}
 	defer func() {
-		state.audit.AuditScenarioStep(stepTrace.String(), payload, err)
+		state.audit.AuditScenarioStep2(state.currentStep, stepTrace.String(), payload, err)
 	}()
 	err = fmt.Errorf("Not Implemented")
 	stepTrace.WriteString("TODO: Pending implementation;")
@@ -357,5 +358,13 @@ func (p ProbeStruct) ScenarioInitialize(ctx *godog.ScenarioContext) {
 
 	ctx.AfterScenario(func(s *godog.Scenario, err error) {
 		coreengine.LogScenarioEnd(s)
+	})
+
+	ctx.BeforeStep(func(st *godog.Step) {
+		p.state.currentStep = st.Text
+	})
+
+	ctx.AfterStep(func(st *godog.Step, err error) {
+		p.state.currentStep = ""
 	})
 }


### PR DESCRIPTION
Adding copy of audit functions to support logging scenario step name
Copy should be removed once all probes have been upgraded.

To capture scenario step name, all probes shall add the following code blocks:

- Add `currentStep` to `scenarioState` struct

```
// scenarioState holds the steps and state for any scenario in this probe
type scenarioState struct {
	name        string
	currentStep string
        ...
}
```

- Capture step name in scenario state (and clear)

```
func (probe probeStruct) ScenarioInitialize(ctx *godog.ScenarioContext) {

	//...

	ctx.BeforeStep(func(st *godog.Step) {
		scenario.currentStep = st.Text
	})

	ctx.AfterStep(func(st *godog.Step, err error) {
		scenario.currentStep = ""
	})
}
```
