### PR TITLE
Corrected podsecurity feature for privileged commands

### DIFF
--- a/service_packs/kubernetes/connection/connection.go
+++ b/service_packs/kubernetes/connection/connection.go
@@ -38,7 +38,7 @@ type Connection interface {
 	ClusterIsDeployed() error
 	CreatePodFromObject(pod *apiv1.Pod, probeName string) (*apiv1.Pod, error)
 	DeletePodIfExists(podName, namespace, probeName string) error
-	ExecCommand(command, namespace, podName string) (status int, stdout string, err error)
+	ExecCommand(command, namespace, podName string) (status int, stdout string, stderr string, err error)
 	GetPodsByNamespace(namespace string) (*apiv1.PodList, error)
 	GetPodIPs(namespace, podName string) (string, string, error)
 	GetRawResourceByName(apiEndPoint, namespace, resourceType, resourceName string) (resource APIResource, err error)
@@ -154,7 +154,7 @@ func (connection *Conn) DeletePodIfExists(podName, namespace, probeName string) 
 }
 
 // ExecCommand executes the supplied command on the given pod name in the specified namespace.
-func (connection *Conn) ExecCommand(cmd, namespace, podName string) (status int, stdout string, err error) {
+func (connection *Conn) ExecCommand(cmd, namespace, podName string) (status int, stdout string, stderr string, err error) {
 	status = -1
 	if cmd == "" {
 		err = utils.ReformatError("Command string not provided to ExecCommand")
@@ -198,6 +198,7 @@ func (connection *Conn) ExecCommand(cmd, namespace, podName string) (status int,
 		Tty:    false,
 	})
 	stdout = stdoutBuffer.String()
+	stderr = stderrBuffer.String()
 	if err != nil {
 		if exit, ok := err.(executil.CodeExitError); ok {
 			//the command has been executed on the container, but the underlying command raised an error

--- a/service_packs/kubernetes/connection/connection.go
+++ b/service_packs/kubernetes/connection/connection.go
@@ -202,7 +202,7 @@ func (connection *Conn) ExecCommand(cmd, namespace, podName string) (status int,
 		if exit, ok := err.(executil.CodeExitError); ok {
 			//the command has been executed on the container, but the underlying command raised an error
 			//this is an 'external' error and represents a successful communication with the cluster
-			err = utils.ReformatError(fmt.Sprintf("err: %s ; stdout: %s ; stderr: %s", err, stdout, stderrBuffer.String()))
+			err = utils.ReformatError(fmt.Sprintf("err: %s ; stderr: %s", err, stderrBuffer.String()))
 			status = exit.Code
 			return
 		}

--- a/service_packs/kubernetes/general/general.go
+++ b/service_packs/kubernetes/general/general.go
@@ -165,7 +165,7 @@ func (scenario *scenarioState) theResultOfAProcessInsideThePodEstablishingADirec
 	cmd := "curl -s -o /dev/null -I -L -w %{http_code} " + urlAddress
 
 	stepTrace.WriteString(fmt.Sprintf("Attempt to run command in the pod: '%s'; ", cmd))
-	exitCode, stdOut, cmdErr := conn.ExecCommand(cmd, scenario.namespace, scenario.pods[0])
+	exitCode, stdOut, _, cmdErr := conn.ExecCommand(cmd, scenario.namespace, scenario.pods[0])
 
 	// Validate that no internal error occurred during execution of curl command
 	if cmdErr != nil && exitCode == -1 {

--- a/service_packs/kubernetes/iam/iam.go
+++ b/service_packs/kubernetes/iam/iam.go
@@ -235,7 +235,7 @@ func (scenario *scenarioState) anAttemptToObtainAnAccessTokenFromThatPodShouldX(
 	cmd := "curl http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https%3A%2F%2Fmanagement.azure.com%2F -H Metadata:true -s"
 
 	stepTrace.WriteString(fmt.Sprintf("Attempt to run command in the pod: '%s'; ", cmd))
-	_, stdOut, cmdErr := conn.ExecCommand(cmd, scenario.namespace, podName)
+	_, stdOut, _, cmdErr := conn.ExecCommand(cmd, scenario.namespace, podName)
 
 	// Validate that no internal error occurred during execution of curl command
 	if cmdErr != nil {
@@ -396,7 +396,7 @@ func (scenario *scenarioState) theExecutionOfAXCommandInsideTheMICPodIsY(command
 	identityPodsNamespace := config.Vars.ServicePacks.Kubernetes.Azure.IdentityNamespace
 	stepTrace.WriteString(fmt.Sprintf(
 		"Attempt to execute command '%s' in MIC pod '%s'; ", cmd, scenario.micPodName))
-	exitCode, stdOut, cmdErr := conn.ExecCommand(cmd, identityPodsNamespace, scenario.micPodName)
+	exitCode, stdOut, _, cmdErr := conn.ExecCommand(cmd, identityPodsNamespace, scenario.micPodName)
 
 	// Validate that no internal error occurred during execution of curl command
 	if cmdErr != nil && exitCode == -1 {

--- a/service_packs/kubernetes/podsecurity/podsecurity.feature
+++ b/service_packs/kubernetes/podsecurity/podsecurity.feature
@@ -35,7 +35,7 @@ Feature: Pod Security
 
         When pod creation "succeeds" with "allowPrivilegeEscalation" set to "<VALUE>" in the pod spec
         Then the execution of a "non-privileged" command inside the pod is "successful"
-        But the execution of a "sudo" command inside the pod is "not executable"
+        But the execution of a "privileged" command inside the pod is "not executable"
 
         Examples:
             | VALUE                     |
@@ -43,7 +43,7 @@ Feature: Pod Security
             | false                     |
 
     @k-pod-003
-    Scenario Outline: Prevent a deployment from running in the host's process tree namespace
+    Scenario: Prevent a deployment from running in the host's process tree namespace
 
         HostPID controls whether a pod's containers can share the host process ID namespace.
         If paired with ptrace, this can be used to escalate privileges outside of the container.
@@ -56,7 +56,7 @@ Feature: Pod Security
         Then pod creation "fails" with "hostPID" set to "true" in the pod spec
 
     @k-pod-004
-    Scenario: Prevent execution of commands that allow privileged access
+    Scenario Outline: Prevent execution of commands that allow privileged access
 
         By default pods that don't specify a value for hostPID should not have the ability to
         gain access to processes outside of the pod's process tree.
@@ -88,7 +88,7 @@ Feature: Pod Security
         Then pod creation "fails" with "hostIPC" set to "true" in the pod spec
 
     @k-pod-006
-    Scenario: Prevent a deployment from running with access to the shared host IPC namespace
+    Scenario Outline: Prevent a deployment from running with access to the shared host IPC namespace
 
         By default pods that don't specify whether Host IPC namespace mode is set should not
         be able to access the shared host IPC namespace.
@@ -121,7 +121,7 @@ Feature: Pod Security
         Then pod creation "fails" with "hostNetwork" set to "true" in the pod spec
 
     @k-pod-008
-    Scenario: Prevent execution of commands that allow access to the host's network namespace access
+    Scenario Outline: Prevent execution of commands that allow access to the host's network namespace access
 
         By default pods that don't specify whether access to host's network namespace is required should not be able to access the host's network namespace.
 
@@ -175,3 +175,16 @@ Feature: Pod Security
 
         When pod creation "succeeds" with "annotations" set to "include seccomp profile" in the pod spec
         Then pod creation "fails" with "annotations" set to "not include seccomp profile" in the pod spec
+
+    # @k-pod-012
+    # Scenario: Ensure that pods cannot use the NET_RAW capability
+
+    #     The NET_RAW capability is assigned by default if Docker is the container runtime,
+    #     but it introduces vulnerabilities that may be exploited by malicious containers.
+
+    #     Security Standard References:
+    #         - CIS Kubernetes Benchmark v1.6.0 - 5.2.7
+
+    #     When pod creation "fails" with "capabilities" set to "include NET_RAW" in the pod spec
+    #     Then pod creation "succeeds" with "capabilities" set to "not include NET_RAW" in the pod spec
+    #     And the execution of a "root" command inside the pod is "unsuccessful"

--- a/service_packs/kubernetes/podsecurity/podsecurity.feature
+++ b/service_packs/kubernetes/podsecurity/podsecurity.feature
@@ -35,7 +35,7 @@ Feature: Pod Security
 
         When pod creation "succeeds" with "allowPrivilegeEscalation" set to "<VALUE>" in the pod spec
         Then the execution of a "non-privileged" command inside the pod is "successful"
-        But the execution of a "privileged" command inside the pod is "not executable"
+        But the execution of a "privileged" command inside the pod is "prevented by restricted permissions"
 
         Examples:
             | VALUE                     |

--- a/service_packs/kubernetes/podsecurity/podsecurity.feature
+++ b/service_packs/kubernetes/podsecurity/podsecurity.feature
@@ -175,16 +175,3 @@ Feature: Pod Security
 
         When pod creation "succeeds" with "annotations" set to "include seccomp profile" in the pod spec
         Then pod creation "fails" with "annotations" set to "not include seccomp profile" in the pod spec
-
-    # @k-pod-012
-    # Scenario: Ensure that pods cannot use the NET_RAW capability
-
-    #     The NET_RAW capability is assigned by default if Docker is the container runtime,
-    #     but it introduces vulnerabilities that may be exploited by malicious containers.
-
-    #     Security Standard References:
-    #         - CIS Kubernetes Benchmark v1.6.0 - 5.2.7
-
-    #     When pod creation "fails" with "capabilities" set to "include NET_RAW" in the pod spec
-    #     Then pod creation "succeeds" with "capabilities" set to "not include NET_RAW" in the pod spec
-    #     And the execution of a "root" command inside the pod is "unsuccessful"

--- a/service_packs/kubernetes/podsecurity/podsecurity.go
+++ b/service_packs/kubernetes/podsecurity/podsecurity.go
@@ -109,6 +109,8 @@ func (scenario *scenarioState) podCreationResultsWithXSetToYInThePodSpec(result,
 		err = userPodSpecModifier(pod, value)
 	case "annotations":
 		err = annotationsPodSpecModifier(pod, value)
+	case "capabilities":
+		err = capabilitiesPodSpecModifier(pod, value)
 	default:
 		if value == "true" || value == "false" {
 			err = boolPodSpecModifier(pod, key, value)
@@ -177,6 +179,8 @@ func (scenario *scenarioState) theExecutionOfAXCommandInsideThePodIsY(permission
 		cmd = "ls"
 	case "sudo":
 		cmd = "sudo ls"
+	case "privileged":
+		cmd = "mount /fake /fake"
 	case "root":
 		cmd = "touch /dev/probr"
 	default:
@@ -190,24 +194,24 @@ func (scenario *scenarioState) theExecutionOfAXCommandInsideThePodIsY(permission
 		expectedExitCode = 0
 	case "unsuccessful":
 		expectedExitCode = 1
-	case "not executable":
-		// If a command is found but is not executable, the return status is 126
-		// Known issue: we can't guarantee that the 126 recieved by kubectl isn't a masked 127
-		expectedExitCode = 126
+	case "prevented by restricted permissions":
+		expectedExitCode = 32
 	default:
 		err = utils.ReformatError("Unexpected value provided for expected command result: %s", result) // No payload is necessary if an invalid value was provided
 		return err
 
 	}
 	stepTrace.WriteString("Attempt to run a command in the pod that was created by the previous step; ")
-	exitCode, _, err := conn.ExecCommand(cmd, scenario.namespace, scenario.pods[0])
+	exitCode, stdout, err := conn.ExecCommand(cmd, scenario.namespace, scenario.pods[0])
 
 	payload = struct {
 		Command          string
+		StdOut           string
 		ExitCode         int
 		ExpectedExitCode int
 	}{
 		Command:          cmd,
+		StdOut:           stdout,
 		ExitCode:         exitCode,
 		ExpectedExitCode: expectedExitCode,
 	}
@@ -411,6 +415,17 @@ func annotationsPodSpecModifier(pod *apiv1.Pod, value string) (err error) {
 		pod.ObjectMeta.Annotations = nil
 	default:
 		err = utils.ReformatError("Expected 'include seccomp profile' or 'not include seccomp profile', but found '%s'", value) // No payload is necessary if an invalid value was provided
+	}
+	return
+}
+
+func capabilitiesPodSpecModifier(pod *apiv1.Pod, value string) (err error) {
+	switch value {
+	case "include NET_RAW":
+
+	case "not include NET_RAW":
+	default:
+		err = utils.ReformatError("Expected 'include NET_RAW' or 'not include NET_RAW', but found '%s'", value) // No payload is necessary if an invalid value was provided
 	}
 	return
 }

--- a/service_packs/kubernetes/podsecurity/podsecurity.go
+++ b/service_packs/kubernetes/podsecurity/podsecurity.go
@@ -177,8 +177,6 @@ func (scenario *scenarioState) theExecutionOfAXCommandInsideThePodIsY(permission
 	switch permission {
 	case "non-privileged":
 		cmd = "ls"
-	case "sudo":
-		cmd = "sudo ls"
 	case "privileged":
 		cmd = "mount /fake /fake"
 	case "root":

--- a/service_packs/kubernetes/podsecurity/podsecurity.go
+++ b/service_packs/kubernetes/podsecurity/podsecurity.go
@@ -202,16 +202,18 @@ func (scenario *scenarioState) theExecutionOfAXCommandInsideThePodIsY(permission
 
 	}
 	stepTrace.WriteString("Attempt to run a command in the pod that was created by the previous step; ")
-	exitCode, stdout, err := conn.ExecCommand(cmd, scenario.namespace, scenario.pods[0])
+	exitCode, stdout, stderr, err := conn.ExecCommand(cmd, scenario.namespace, scenario.pods[0])
 
 	payload = struct {
 		Command          string
 		StdOut           string
+		StdErr           string
 		ExitCode         int
 		ExpectedExitCode int
 	}{
 		Command:          cmd,
 		StdOut:           stdout,
+		StdErr:           stderr,
 		ExitCode:         exitCode,
 		ExpectedExitCode: expectedExitCode,
 	}
@@ -242,7 +244,7 @@ func (scenario *scenarioState) aXInspectionShouldOnlyShowTheContainerProcesses(i
 		return
 	}
 	entrypoint := strings.Join(constructors.DefaultEntrypoint(), " ")
-	exitCode, stdout, err := conn.ExecCommand(command, scenario.namespace, scenario.pods[0])
+	exitCode, stdout, _, err := conn.ExecCommand(command, scenario.namespace, scenario.pods[0])
 
 	if err != nil {
 		// TODO: Validate that this fails as expected


### PR DESCRIPTION
Updated step output:
```
          "Function": "theExecutionOfAXCommandInsideThePodIsY",
          "Name": "the execution of a \"privileged\" command inside the pod is \"prevented by restricted permissions\"",
          "Description": "Attempt to run a command in the pod that was created by the previous step; ",
          "Result": "Passed",
          "Error": "",
          "Payload": {
            "Command": "mount /fake /fake",
            "StdOut": "",
            "StdErr": "mount: /fake: must be superuser to use mount.\n",
            "ExitCode": 32,
            "ExpectedExitCode": 32
          }
```