### PR TITLE
Corrected for GCP bug

### DIFF
--- a/service_packs/kubernetes/connection/connection.go
+++ b/service_packs/kubernetes/connection/connection.go
@@ -19,6 +19,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
+	_ "k8s.io/client-go/plugin/pkg/client/auth" // required
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
@@ -355,7 +356,11 @@ func (connection *Conn) setClientConfig() {
 }
 
 func (connection *Conn) bootstrapDefaultNamespace() {
-	_, err := connection.GetOrCreateNamespace(config.Vars.ServicePacks.Kubernetes.ProbeNamespace)
+	err := connection.ClusterIsDeployed()
+	if err != nil {
+		return
+	}
+	_, err = connection.GetOrCreateNamespace(config.Vars.ServicePacks.Kubernetes.ProbeNamespace)
 	if err != nil {
 		connection.clusterIsDeployed = utils.ReformatError("Failed to retrieve or create default Probr namespace: %v", err)
 	}


### PR DESCRIPTION
- added silent import of client-go auth pkg
- check for deployment before attempting to bootstrap namespace