### PR TITLE
Adding expected message to handle AZF exiting 0 when denying

### DIFF
--- a/service_packs/kubernetes/general/general.go
+++ b/service_packs/kubernetes/general/general.go
@@ -154,7 +154,7 @@ func (scenario *scenarioState) theResultOfAProcessInsideThePodEstablishingADirec
 	// 6: Couldn't resolve host
 	// 28: command timed out
 	expectedExitCodes := []int{6, 28}
-	expectedExitMessage := "Action: Deny"
+	expectedExitMessage := "Action: Deny"           // TODO: This is the AZF response. Consider making this a config option, or extend to include other potential responses.
 	cmd := fmt.Sprintf("curl -m 10 %s", urlAddress) // 10 second timeout should be enough
 
 	stepTrace.WriteString("Attempt to run curl command in the pod; ")


### PR DESCRIPTION
For reference:
https://microsoftlearning.github.io/AZ500-AzureSecurityTechnologies/Instructions/Labs/LAB_08_AzureFirewall.html

![image](https://user-images.githubusercontent.com/21176439/114398047-57b2ac80-9b6d-11eb-8318-4b3ed508eff5.png)
