### PR TITLE
Added check to ensure pods are always deleted

### DIFF
--- a/service_packs/kubernetes/connection/aks/aks.go
+++ b/service_packs/kubernetes/connection/aks/aks.go
@@ -44,7 +44,7 @@ func (aks *AKS) CreateAIB(namespace, aibName, aiName string) (resource connectio
 	apiPath := "apis/aadpodidentity.k8s.io/v1"
 
 	resource, err = aks.conn.PostRawResource(apiPath, namespace, "azureidentitybindings", runtimeAib)
-	log.Printf("Resource %v", resource)
+	log.Printf("[DEBUG] Identity binding resource posted: %v", resource)
 
 	return
 }

--- a/service_packs/kubernetes/container_registry_access/container_registry_access.go
+++ b/service_packs/kubernetes/container_registry_access/container_registry_access.go
@@ -225,7 +225,7 @@ func getImageFromConfig(accessLevel bool) string {
 
 func (scenario *scenarioState) createPodfromObject(podObject *apiv1.Pod) (createdPodObject *apiv1.Pod, err error) {
 	createdPodObject, err = conn.CreatePodFromObject(podObject, Probe.Name())
-	if err == nil {
+	if createdPodObject != nil && createdPodObject.ObjectMeta.Name != "" {
 		scenario.pods = append(scenario.pods, createdPodObject.ObjectMeta.Name)
 	}
 	return

--- a/service_packs/kubernetes/general/general.go
+++ b/service_packs/kubernetes/general/general.go
@@ -279,7 +279,7 @@ func afterScenario(scenario scenarioState, probe probeStruct, gs *godog.Scenario
 
 func (scenario *scenarioState) createPodfromObject(podObject *apiv1.Pod) (createdPodObject *apiv1.Pod, err error) {
 	createdPodObject, err = conn.CreatePodFromObject(podObject, Probe.Name())
-	if err == nil {
+	if createdPodObject != nil && createdPodObject.ObjectMeta.Name != "" {
 		scenario.pods = append(scenario.pods, createdPodObject.ObjectMeta.Name)
 	}
 	return

--- a/service_packs/kubernetes/iam/iam.go
+++ b/service_packs/kubernetes/iam/iam.go
@@ -524,7 +524,7 @@ func afterScenario(scenario scenarioState, probe probeStruct, gs *godog.Scenario
 
 func (scenario *scenarioState) createPodfromObject(podObject *apiv1.Pod) (createdPodObject *apiv1.Pod, err error) {
 	createdPodObject, err = conn.CreatePodFromObject(podObject, Probe.Name())
-	if err == nil {
+	if createdPodObject != nil && createdPodObject.ObjectMeta.Name != "" {
 		scenario.pods = append(scenario.pods, createdPodObject.ObjectMeta.Name)
 	}
 	return

--- a/service_packs/kubernetes/podsecurity/podsecurity.go
+++ b/service_packs/kubernetes/podsecurity/podsecurity.go
@@ -41,7 +41,7 @@ var scenario scenarioState
 
 func (scenario *scenarioState) createPodfromObject(podObject *apiv1.Pod) (createdPodObject *apiv1.Pod, err error) {
 	createdPodObject, err = conn.CreatePodFromObject(podObject, Probe.Name())
-	if err == nil {
+	if createdPodObject != nil && createdPodObject.ObjectMeta.Name != "" {
 		scenario.pods = append(scenario.pods, createdPodObject.ObjectMeta.Name)
 	}
 	return


### PR DESCRIPTION
Previously pods with an imagepullerr were slipping through the cracks and being left as residue on the target cluster.